### PR TITLE
allow for paths relative to the current dir

### DIFF
--- a/org.xpect/src/org/xpect/runner/XpectTestFiles.java
+++ b/org.xpect/src/org/xpect/runner/XpectTestFiles.java
@@ -43,7 +43,7 @@ public @interface XpectTestFiles {
 	}
 
 	public static enum FileRoot {
-		CLASS, PROJECT
+		CURRENT, CLASS, PROJECT
 	}
 
 	public static class XpectTestFileCollector implements IXpectURIProvider {
@@ -115,6 +115,8 @@ public @interface XpectTestFiles {
 
 		protected File getBaseDir() {
 			switch (ctx.relativeTo()) {
+			case CURRENT:
+				return new File(ctx.baseDir());
 			case CLASS:
 				File base = getOwningJavaClassFolder(owner);
 				if (ctx.baseDir() != null && !"".equals(ctx.baseDir()))


### PR DESCRIPTION
Hi Moritz,
I have added another way of specifying the file root: Just take the CURRENT dir.
This is useful if the test files are located in another (sub)project. In this case, CLASS relative is not helpful since the class location can be different in Eclipse and Maven environment. PROJECT would have helped here, but I couldn't figure out a way how to determine it that will work in all different environments without applying a good portion of guesswork.
Maybe that's something you'd like to consider?
Cheers,
Simon
