### PR TITLE
Using original URI when creating resources

### DIFF
--- a/org.xpect.xtext.lib/src/org/xpect/xtext/lib/setup/XtextStandaloneSetup.java
+++ b/org.xpect.xtext.lib/src/org/xpect/xtext/lib/setup/XtextStandaloneSetup.java
@@ -21,6 +21,7 @@ import org.xpect.parameter.ParameterProvider;
 import org.xpect.parameter.XpectParameterAdapter;
 import org.xpect.setup.AbstractXpectSetup;
 import org.xpect.setup.ISetupInitializer;
+import org.xpect.util.URIDelegationHandler;
 import org.xpect.xtext.lib.setup.ThisOffset.ThisOffsetProvider;
 import org.xpect.xtext.lib.setup.XtextStandaloneSetup.ClassCtx;
 import org.xpect.xtext.lib.setup.XtextStandaloneSetup.TestCtx;
@@ -78,8 +79,9 @@ public class XtextStandaloneSetup extends AbstractXpectSetup<ClassCtx, FileCtx, 
 		if (userCtx.getResourceSet() != null) {
 			Resource result = null;
 			for (ISetupFile file : userCtx.getResourceSet().getFiles()) {
+				URI originalURI = new URIDelegationHandler().getOriginalURI(file.getURI(frameworkCtx));
 				Injector langInjector = frameworkCtx.getInjector(file.getURI(frameworkCtx));
-				Resource res = langInjector.getInstance(IResourceFactory.class).createResource(file.getURI(frameworkCtx));
+				Resource res = langInjector.getInstance(IResourceFactory.class).createResource(originalURI);
 				resourceSet.getResources().add(res);
 				res.load(file.createInputStream(frameworkCtx), null);
 				if (file instanceof ThisFile)
@@ -88,7 +90,9 @@ public class XtextStandaloneSetup extends AbstractXpectSetup<ClassCtx, FileCtx, 
 			return (XtextResource) result;
 		} else {
 			URI thisURI = frameworkCtx.getXpectFile().eResource().getURI();
-			Resource res = injector.getInstance(IResourceFactory.class).createResource(thisURI);
+			Injector langInjector = frameworkCtx.getInjector(thisURI);
+			URI originalURI = new URIDelegationHandler().getOriginalURI(thisURI);
+			Resource res = langInjector.getInstance(IResourceFactory.class).createResource(originalURI);
 			resourceSet.getResources().add(res);
 			res.load(resourceSet.getURIConverter().createInputStream(thisURI), null);
 			return (XtextResource) res;

--- a/org.xpect/src/org/xpect/util/URIDelegationHandler.java
+++ b/org.xpect/src/org/xpect/util/URIDelegationHandler.java
@@ -17,12 +17,11 @@ public class URIDelegationHandler {
 
 	public URI getOriginalURI(URI uri) {
 		String ext = uri.fileExtension();
-		if (ext == null || !"xt".equals(ext))
-			return null;
-		URI trimmed = uri.trimFileExtension();
-		if (trimmed.fileExtension() == null)
-			return null;
-		return trimmed;
+		if (ext == null || !"xt".equals(ext)) {
+			return uri;
+		} else {
+			return uri.trimFileExtension();
+		}
 	}
 
 	public String getOriginalFileExtension(String simpleFilename) {


### PR DESCRIPTION
If resource URIs have the ".xt" suffix, several tests result in false
negatives (e.g. validation tests) because later injector lookups
might end up with the wrong injector as the productive coding
does not know the ".xt" language.
