### PR TITLE
Registering xt in the Resource Service Registry

### DIFF
--- a/org.xpect.xtext.lib/src/org/xpect/xtext/lib/setup/XtextStandaloneSetup.java
+++ b/org.xpect.xtext.lib/src/org/xpect/xtext/lib/setup/XtextStandaloneSetup.java
@@ -19,6 +19,7 @@ import org.eclipse.xtext.xbase.jvmmodel.JvmModelInferrerRegistry;
 import org.xpect.Environment;
 import org.xpect.parameter.ParameterProvider;
 import org.xpect.parameter.XpectParameterAdapter;
+import org.xpect.services.XtResourceServiceProviderProvider;
 import org.xpect.setup.AbstractXpectSetup;
 import org.xpect.setup.ISetupInitializer;
 import org.xpect.xtext.lib.setup.ThisOffset.ThisOffsetProvider;
@@ -42,6 +43,7 @@ public class XtextStandaloneSetup extends AbstractXpectSetup<ClassCtx, FileCtx, 
 	@Override
 	public ClassCtx beforeClass(IClassSetupContext frameworkCtx) {
 		JvmModelInferrerRegistry.INSTANCE.setUseRegistry(false);
+		XtResourceServiceProviderProvider.INSTANCE.setSetupContext(frameworkCtx);
 		return new ClassCtx();
 	}
 

--- a/org.xpect/src/org/xpect/registry/StandaloneLanguageRegistry.java
+++ b/org.xpect/src/org/xpect/registry/StandaloneLanguageRegistry.java
@@ -26,6 +26,7 @@ import org.xpect.registry.StandalonePluginXMLParser.EMFExtensionParserInfo;
 import org.xpect.registry.StandalonePluginXMLParser.EMFGeneratedPackageInfo;
 import org.xpect.registry.StandalonePluginXMLParser.EditorInfo;
 import org.xpect.registry.StandalonePluginXMLParser.ExtensionInfo;
+import org.xpect.services.XtResourceServiceProviderProvider;
 
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Maps;
@@ -237,7 +238,7 @@ public class StandaloneLanguageRegistry implements ILanguageInfo.Registry {
 					ext2language.put(ext, info);
 			}
 		}
-		registerXpectRSPforXt();
+		registerRSPProviderForXt();
 	}
 
 	public ILanguageInfo getLanguageByFileExtension(String fileExtension) {
@@ -281,12 +282,10 @@ public class StandaloneLanguageRegistry implements ILanguageInfo.Registry {
 		EcorePlugin.getEPackageNsURIToGenModelLocationMap().put(info.getUri(), URI.createURI(info.getGenModel()));
 	}
 
-	protected void registerXpectRSPforXt() {
+	protected void registerRSPProviderForXt() {
 		if (IResourceServiceProvider.Registry.INSTANCE.getExtensionToFactoryMap().get(XpectConstants.XT_FILE_EXT) == null) {
-			Object xpectRSP = IResourceServiceProvider.Registry.INSTANCE.getExtensionToFactoryMap().get(XpectConstants.XPECT_FILE_EXT);
-			if (xpectRSP != null) {
-				IResourceServiceProvider.Registry.INSTANCE.getExtensionToFactoryMap().put(XpectConstants.XT_FILE_EXT, xpectRSP);
-			}
+			IResourceServiceProvider.Registry.INSTANCE.getExtensionToFactoryMap().put(XpectConstants.XT_FILE_EXT,
+					XtResourceServiceProviderProvider.INSTANCE);
 		}
 	}
 

--- a/org.xpect/src/org/xpect/services/XtResourceServiceProviderProvider.java
+++ b/org.xpect/src/org/xpect/services/XtResourceServiceProviderProvider.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2013 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.xpect.services;
+
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.xtext.resource.IResourceServiceProvider;
+import org.xpect.XpectConstants;
+import org.xpect.registry.ILanguageInfo;
+import org.xpect.setup.IXpectRunnerSetup.IClassSetupContext;
+import org.xpect.util.URIDelegationHandler;
+
+import com.google.inject.Injector;
+
+/**
+ * @author Simon Kaufmann - Initial contribution and API
+ */
+public class XtResourceServiceProviderProvider implements IResourceServiceProvider.Provider {
+
+	public static final XtResourceServiceProviderProvider INSTANCE = new XtResourceServiceProviderProvider();
+
+	private XtResourceServiceProviderProvider() {
+	}
+
+	private ThreadLocal<IClassSetupContext> setupContext = new ThreadLocal<IClassSetupContext>();
+
+	public synchronized void setSetupContext(IClassSetupContext setupContext) {
+		this.setupContext.set(setupContext);
+	}
+
+	private synchronized IClassSetupContext getSetupContext() {
+		return setupContext.get();
+	}
+
+	public IResourceServiceProvider get(URI uri, String contentType) {
+		String ext = new URIDelegationHandler().getOriginalFileExtension(uri.lastSegment());
+		if (ext != null) {
+			ILanguageInfo info = ILanguageInfo.Registry.INSTANCE.getLanguageByFileExtension(ext);
+			if (info == null)
+				throw new IllegalStateException("No Xtext language configuration found for file extension '" + ext + "'.");
+			Injector injector = info.getInjector();
+
+			// consider modules
+			if (getSetupContext() != null) {
+				injector = getSetupContext().getInjector(uri);
+			}
+
+			if (injector != null) {
+				return injector.getInstance(IResourceServiceProvider.class);
+			}
+		}
+		return ILanguageInfo.Registry.INSTANCE.getLanguageByFileExtension(XpectConstants.XT_FILE_EXT).getInjector()
+				.getInstance(IResourceServiceProvider.class);
+	}
+
+}


### PR DESCRIPTION
Hi Moritz,

this is a proposal on how the Resource Service Registry can be filled for "xt" - I'm simply reusing the instance from "xpect" here. However, I'm not really sure if that's the correct way to go, so could you please have a look?

Thanks,
Simon

---

_Background:_
The "xt" DSL does not have an editor (anymore), so there is no corresponding entry in the plugin.xml
that would make the Standalone Registry create an entry for "xt" in the Resource Service Registry. As a result

``` java
resourceServiceProviderRegistry.getResourceServiceProvider(resource.getURI())
```

always returned `null`for "*.xt" resources during test execution.
