### PR TITLE
Add an option to the EObjectFormatter that allows to sort the features alphabetically

### DIFF
--- a/org.xpect.xtext.lib/src/org/xpect/xtext/lib/util/EObjectFormatter.java
+++ b/org.xpect.xtext.lib/src/org/xpect/xtext/lib/util/EObjectFormatter.java
@@ -1,11 +1,9 @@
 package org.xpect.xtext.lib.util;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 
-import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EAttribute;
 import org.eclipse.emf.ecore.EFactory;


### PR DESCRIPTION
Xpect tests become fragile since the internal structure of the EPackage / EClass inheritance directly influences the string representation that is produced by the EObjectFormatter. Things become more stable if the order isn't deduced from the Feature-IDs but from their names. An option to #sortFeaturesByName was helpful in our context and I'd like to contribute it.
