### PR TITLE
Avoid logged CoreException

### DIFF
--- a/org.xpect.ui/src/org/xpect/ui/editor/XpectEditorAssociationOverride.java
+++ b/org.xpect.ui/src/org/xpect/ui/editor/XpectEditorAssociationOverride.java
@@ -57,6 +57,9 @@ public class XpectEditorAssociationOverride implements IEditorAssociationOverrid
 
 	protected boolean hasFavoriteEditor(IFile file) {
 		try {
+			if (!file.exists()) {
+				return false;
+			}
 			String favoriteEditor = file.getPersistentProperty(IDE.EDITOR_KEY);
 			if (favoriteEditor != null)
 				return true;


### PR DESCRIPTION
I saw a lot of logged core exceptions when the dialog was opened that allows to restore files from the local history.
A quick check for file.exists fixed that for me.
