### PR TITLE
adjust Jenkinsfile for eclipse infra

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,9 +10,7 @@
  *******************************************************************************/
 
 timestamps() {
-
-    node {
-
+    node() {
         def mvnHome = tool 'apache-maven-3.0.5'
         def mvnParams = '--batch-mode --update-snapshots -fae -Dmaven.repo.local=xpect-local-maven-repository -DtestOnly=false'
         timeout(time: 1, unit: 'HOURS') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,7 @@ timestamps() {
                 sh """\
                                echo "===== checking tools versions ====="
                                pwd
-                               ls -ls
+                               ls -la
                                ${mvnHome}/bin/mvn -v
                                echo "==================================="
                           """

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,29 +9,30 @@
  *   Moritz Eysholdt - Initial contribution and API
  *******************************************************************************/
 
-// tell Jenkins how to build projects from this repository
-node {
-	
-	def mvnHome = tool 'M3'
-	def mvnParams = '--batch-mode --update-snapshots -fae -Dmaven.repo.local=xpect-local-maven-repository -DtestOnly=false'
+timestamps() {
 
-	stage ('compile with Eclipse Luna and Xtext 2.9.2') {
-		checkout scm
-		sh "${mvnHome}/bin/mvn -P!tests -Dtarget-platform=eclipse_4_4_2-xtext_2_9_2 ${mvnParams} clean install"
-		archive 'org.eclipse.xpect.releng/p2-repository/target/repository/**/*.*'
-	}
-	
-	wrap([$class:'Xvnc', useXauthority: true]) {
-		
-		stage ('test with Eclipse Luna and Xtext 2.9.2') {
-			sh "${mvnHome}/bin/mvn -P!plugins -P!xtext-examples -Dtarget-platform=eclipse_4_4_2-xtext_2_9_2 ${mvnParams} clean integration-test"
-			junit '**/TEST-*.xml'
-		}
-			
-		stage ('test with Eclipse Mars and Xtext nighly') {
-			sh "${mvnHome}/bin/mvn -P!plugins -P!xtext-examples -Dtarget-platform=eclipse_4_5_0-xtext_nightly ${mvnParams} clean integration-test"
-			junit '**/TEST-*.xml'
-		}
-		
-	}
-}  
+    node() {
+
+        def mvnHome = tool 'apache-maven-3.0.5'
+        def mvnParams = '--batch-mode --update-snapshots -fae -Dmaven.repo.local=xpect-local-maven-repository -DtestOnly=false'
+        timeout(time: 1, unit: 'HOURS') {
+            stage('compile with Eclipse Luna and Xtext 2.9.2') {
+                sh "${mvnHome}/bin/mvn -P!tests -Dtarget-platform=eclipse_4_4_2-xtext_2_9_2 ${mvnParams} clean install"
+                archive 'org.eclipse.xpect.releng/p2-repository/target/repository/**/*.*'
+            }
+
+            wrap([$class: 'Xvnc', useXauthority: true]) {
+
+                stage('test with Eclipse Luna and Xtext 2.9.2') {
+                    sh "${mvnHome}/bin/mvn -P!plugins -P!xtext-examples -Dtarget-platform=eclipse_4_4_2-xtext_2_9_2 ${mvnParams} clean integration-test"
+                    junit '**/TEST-*.xml'
+                }
+
+                stage('test with Eclipse Mars and Xtext nighly') {
+                    sh "${mvnHome}/bin/mvn -P!plugins -P!xtext-examples -Dtarget-platform=eclipse_4_5_0-xtext_nightly ${mvnParams} clean integration-test"
+                    junit '**/TEST-*.xml'
+                }
+            }
+        }
+    }
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,12 +23,12 @@ timestamps() {
             stage('log configuration') {
                 echo("===== checking tools versions =====")
                 sh """\
-                               git config --get remote.origin.url
-                               git reset --hard
-                               pwd
-                               ls -la
-                               ${mvnHome}/bin/mvn -v
-                          """
+                       git config --get remote.origin.url
+                       git reset --hard
+                       pwd
+                       ls -la
+                       ${mvnHome}/bin/mvn -v
+                   """
                 echo("===================================")
             }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,6 +16,16 @@ timestamps() {
         def mvnHome = tool 'apache-maven-3.0.5'
         def mvnParams = '--batch-mode --update-snapshots -fae -Dmaven.repo.local=xpect-local-maven-repository -DtestOnly=false'
         timeout(time: 1, unit: 'HOURS') {
+            stage('log configuration') {
+                sh """\
+                               echo "===== checking tools versions ====="
+                               pwd
+                               ls -ls
+                               ${mvnHome}/bin/mvn -v
+                               echo "==================================="
+                          """
+            }
+
             stage('compile with Eclipse Luna and Xtext 2.9.2') {
                 sh "${mvnHome}/bin/mvn -P!tests -Dtarget-platform=eclipse_4_4_2-xtext_2_9_2 ${mvnParams} clean install"
                 archive 'org.eclipse.xpect.releng/p2-repository/target/repository/**/*.*'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,7 +41,7 @@ timestamps() {
 
                 stage('test with Eclipse Luna and Xtext 2.9.2') {
                     try{
-                        sh "${mvnHome}/bin/mvn -P!plugins -P!xtext-examples -Dtarget-platform=eclipse_4_4_2-xtext_2_9_2 ${mvnParams} clean integration-test -X -e"
+                        sh "${mvnHome}/bin/mvn -P!plugins -P!xtext-examples -Dtarget-platform=eclipse_4_4_2-xtext_2_9_2 ${mvnParams} clean integration-test"
                     }finally{
                         junit '**/TEST-*.xml'
                     }
@@ -49,7 +49,7 @@ timestamps() {
 
                 stage('test with Eclipse Mars and Xtext nighly') {
                     try{
-                        sh "${mvnHome}/bin/mvn -P!plugins -P!xtext-examples -Dtarget-platform=eclipse_4_5_0-xtext_nightly ${mvnParams} clean integration-test -X -e"
+                        sh "${mvnHome}/bin/mvn -P!plugins -P!xtext-examples -Dtarget-platform=eclipse_4_5_0-xtext_nightly ${mvnParams} clean integration-test"
                     }finally {
                         junit '**/TEST-*.xml'
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,6 +21,8 @@ timestamps() {
             stage('log configuration') {
                 sh """\
                                echo "===== checking tools versions ====="
+                               git status
+                               git log
                                pwd
                                ls -la
                                ${mvnHome}/bin/mvn -v

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,6 +14,10 @@ timestamps() {
         def mvnHome = tool 'apache-maven-3.0.5'
         def mvnParams = '--batch-mode --update-snapshots -fae -Dmaven.repo.local=xpect-local-maven-repository -DtestOnly=false'
         timeout(time: 1, unit: 'HOURS') {
+            stage('git checkout') {
+                checkout scm
+            }
+
             stage('log configuration') {
                 sh """\
                                echo "===== checking tools versions ====="

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -40,13 +40,19 @@ timestamps() {
             wrap([$class: 'Xvnc', useXauthority: true]) {
 
                 stage('test with Eclipse Luna and Xtext 2.9.2') {
-                    sh "${mvnHome}/bin/mvn -P!plugins -P!xtext-examples -Dtarget-platform=eclipse_4_4_2-xtext_2_9_2 ${mvnParams} clean integration-test"
-                    junit '**/TEST-*.xml'
+                    try{
+                        sh "${mvnHome}/bin/mvn -P!plugins -P!xtext-examples -Dtarget-platform=eclipse_4_4_2-xtext_2_9_2 ${mvnParams} clean integration-test"
+                    }finally{
+                        junit '**/TEST-*.xml'
+                    }
                 }
 
                 stage('test with Eclipse Mars and Xtext nighly') {
-                    sh "${mvnHome}/bin/mvn -P!plugins -P!xtext-examples -Dtarget-platform=eclipse_4_5_0-xtext_nightly ${mvnParams} clean integration-test"
-                    junit '**/TEST-*.xml'
+                    try{
+                        sh "${mvnHome}/bin/mvn -P!plugins -P!xtext-examples -Dtarget-platform=eclipse_4_5_0-xtext_nightly ${mvnParams} clean integration-test"
+                    }finally {
+                        junit '**/TEST-*.xml'
+                    }
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@
 timestamps() {
     node() {
         def mvnHome = tool 'apache-maven-3.0.5'
-        def mvnParams = '--batch-mode --update-snapshots -fae -Dmaven.repo.local=xpect-local-maven-repository -DtestOnly=false'
+        def mvnParams = '-fae -Dmaven.repo.local=xpect-local-maven-repository -DtestOnly=false'
         timeout(time: 1, unit: 'HOURS') {
             stage('prepare workspace') {
                 step([$class: 'WsCleanup'])
@@ -33,7 +33,7 @@ timestamps() {
             }
 
             stage('compile with Eclipse Luna and Xtext 2.9.2') {
-                sh "${mvnHome}/bin/mvn -P!tests -Dtarget-platform=eclipse_4_4_2-xtext_2_9_2 ${mvnParams} clean install"
+                sh "${mvnHome}/bin/mvn -P!tests -Dtarget-platform=eclipse_4_4_2-xtext_2_9_2 ${mvnParams} --batch-mode --update-snapshots clean install"
                 archive 'org.eclipse.xpect.releng/p2-repository/target/repository/**/*.*'
             }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@
 
 timestamps() {
 
-    node() {
+    node {
 
         def mvnHome = tool 'apache-maven-3.0.5'
         def mvnParams = '--batch-mode --update-snapshots -fae -Dmaven.repo.local=xpect-local-maven-repository -DtestOnly=false'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,6 +24,10 @@ timestamps() {
                                ${mvnHome}/bin/mvn -v
                                echo "==================================="
                           """
+                //clone
+                timeout(time: 30, unit: 'MINUTES') {
+                    gitCheckout("xpect_force_clone", scm.userRemoteConfigs, scm.branches[0].name)
+                }
             }
 
             stage('compile with Eclipse Luna and Xtext 2.9.2') {
@@ -45,4 +49,27 @@ timestamps() {
             }
         }
     }
+}
+
+
+//======
+
+/**
+ * Helper function that performs git checkout.
+ * Note that for the remote user can pass either inherited remote config,
+ * or assuming you have git url like {@code git@github.com:Profile/repo.git}, then you can in place create config
+ * by passing {@code [[url: git@github.com:Profile/repo.git]]}
+ *
+ * @param checkoutDir string with directory name where to checkout, relative to the workspace
+ * @param gitRemote scm object configuring remote ({@code scm.userRemoteConfigs})
+ * @param branch branch name to checkout (it is String but cannot infer from scm object)
+ */
+@NonCPS
+def gitCheckout(String checkoutDir, Object gitRemote, Object branch) {
+    checkout poll: false, scm: [ $class                             : 'GitSCM'
+                                 , branches                         : [[name: branch]]
+                                 , doGenerateSubmoduleConfigurations: false
+                                 , extensions                       : [ [$class: 'RelativeTargetDirectory', relativeTargetDir: checkoutDir],
+                                                                        [$class: 'CloneOption', depth: 0, noTags: false, shallow: true]]
+                                 , userRemoteConfigs                : gitRemote]
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@
 timestamps() {
     node() {
         def mvnHome = tool 'apache-maven-3.0.5'
-        def mvnParams = '-fae -Dmaven.repo.local=xpect-local-maven-repository -DtestOnly=false'
+        def mvnParams = '--batch-mode --update-snapshots -fae -Dmaven.repo.local=xpect-local-maven-repository -DtestOnly=false'
         timeout(time: 1, unit: 'HOURS') {
             stage('prepare workspace') {
                 step([$class: 'WsCleanup'])
@@ -41,7 +41,7 @@ timestamps() {
 
                 stage('test with Eclipse Luna and Xtext 2.9.2') {
                     try{
-                        sh "${mvnHome}/bin/mvn -P!plugins -P!xtext-examples -Dtarget-platform=eclipse_4_4_2-xtext_2_9_2 ${mvnParams} clean integration-test"
+                        sh "${mvnHome}/bin/mvn -P!plugins -P!xtext-examples -Dtarget-platform=eclipse_4_4_2-xtext_2_9_2 ${mvnParams} clean integration-test -X -e"
                     }finally{
                         junit '**/TEST-*.xml'
                     }
@@ -49,7 +49,7 @@ timestamps() {
 
                 stage('test with Eclipse Mars and Xtext nighly') {
                     try{
-                        sh "${mvnHome}/bin/mvn -P!plugins -P!xtext-examples -Dtarget-platform=eclipse_4_5_0-xtext_nightly ${mvnParams} clean integration-test"
+                        sh "${mvnHome}/bin/mvn -P!plugins -P!xtext-examples -Dtarget-platform=eclipse_4_5_0-xtext_nightly ${mvnParams} clean integration-test -X -e"
                     }finally {
                         junit '**/TEST-*.xml'
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,10 +24,6 @@ timestamps() {
                                ${mvnHome}/bin/mvn -v
                                echo "==================================="
                           """
-                //clone
-                timeout(time: 30, unit: 'MINUTES') {
-                    gitCheckout("xpect_force_clone", scm.userRemoteConfigs, scm.branches[0].name)
-                }
             }
 
             stage('compile with Eclipse Luna and Xtext 2.9.2') {
@@ -49,27 +45,4 @@ timestamps() {
             }
         }
     }
-}
-
-
-//======
-
-/**
- * Helper function that performs git checkout.
- * Note that for the remote user can pass either inherited remote config,
- * or assuming you have git url like {@code git@github.com:Profile/repo.git}, then you can in place create config
- * by passing {@code [[url: git@github.com:Profile/repo.git]]}
- *
- * @param checkoutDir string with directory name where to checkout, relative to the workspace
- * @param gitRemote scm object configuring remote ({@code scm.userRemoteConfigs})
- * @param branch branch name to checkout (it is String but cannot infer from scm object)
- */
-@NonCPS
-def gitCheckout(String checkoutDir, Object gitRemote, Object branch) {
-    checkout poll: false, scm: [ $class                             : 'GitSCM'
-                                 , branches                         : [[name: branch]]
-                                 , doGenerateSubmoduleConfigurations: false
-                                 , extensions                       : [ [$class: 'RelativeTargetDirectory', relativeTargetDir: checkoutDir],
-                                                                        [$class: 'CloneOption', depth: 0, noTags: false, shallow: true]]
-                                 , userRemoteConfigs                : gitRemote]
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,20 +14,22 @@ timestamps() {
         def mvnHome = tool 'apache-maven-3.0.5'
         def mvnParams = '--batch-mode --update-snapshots -fae -Dmaven.repo.local=xpect-local-maven-repository -DtestOnly=false'
         timeout(time: 1, unit: 'HOURS') {
-            stage('git checkout') {
+            stage('prepare workspace') {
+                step([$class: 'WsCleanup'])
+                // we need to live with detached head, or we need to adjust settings:
+                // https://issues.jenkins-ci.org/browse/JENKINS-42860
                 checkout scm
             }
-
             stage('log configuration') {
+                echo("===== checking tools versions =====")
                 sh """\
-                               echo "===== checking tools versions ====="
-                               git status
-                               git log
+                               git config --get remote.origin.url
+                               git reset --hard
                                pwd
                                ls -la
                                ${mvnHome}/bin/mvn -v
-                               echo "==================================="
                           """
+                echo("===================================")
             }
 
             stage('compile with Eclipse Luna and Xtext 2.9.2') {

--- a/org.eclipse.xpect.tests/src/org/eclipse/xpect/tests/xjm/AbstractXjmTest.java
+++ b/org.eclipse.xpect.tests/src/org/eclipse/xpect/tests/xjm/AbstractXjmTest.java
@@ -16,14 +16,31 @@ import java.lang.reflect.Constructor;
 import org.eclipse.xtext.junit4.InjectWith;
 import org.eclipse.xtext.junit4.XtextRunner;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
+import org.apache.log4j.Logger;
+import org.eclipse.core.runtime.Platform;
 import org.eclipse.xpect.XpectInjectorProvider;
 import org.eclipse.xpect.XpectJavaModel;
+import org.eclipse.xpect.ui.XpectPluginActivator;
 import org.eclipse.xpect.util.XpectJavaModelManager;
 
 @InjectWith(XpectInjectorProvider.class)
 @RunWith(XtextRunner.class)
 public abstract class AbstractXjmTest {
+	private static final Logger LOG = Logger.getLogger(AbstractXjmTest.class);
+
+	/**
+	 * When running as plugin test we need to ensure that Xpect was activated in the platform.
+	 * Some other tests have side effect of doing that, but relying on that will make this
+	 * test fail when running alone, or when test runner decides on different test order.
+	 * This setup method ensures that when Xpect is activated in the running platform.
+	 */
+	@BeforeClass
+	public static void ensureXpectActivated() {
+		if (Platform.isRunning())
+			LOG.debug("Activating xpect :: " + XpectPluginActivator.getInstance());
+	}
 
 	protected void assertXjm(Class<?> clazz) {
 		try {


### PR DESCRIPTION
resolves #225

This PR contains small modifications to the `Jenkinsfile` to allow building on https://ci.eclipse.org/xpect/
Changes are rather minimal, just enough to address main points of #225 

- [x] https://ci.eclipse.org/xpect/job/Xpect/job/jenkinsfile-eclipse/
- [x] https://ci.eclipse.org/xpect/job/Xpect-Integration-Release/ (temporarily uses this branch)


_issue with failing builds is resolved_

~~Failing build~~
----------
~~note that there is failing build for this branch: https://ci.eclipse.org/xpect/job/Xpect/job/jenkinsfile-eclipse/9/~~

~~It seems some issue is in tests with Eclipse Luna and Xtext 2.9.2
IMHO tests should be fixed in a separate task, i.e. should not block this PR
build log excerpt~~
