### PR TITLE
use old junit to work with newest xtext

### DIFF
--- a/org.eclipse.xpect.releng/xtext-examples/org.eclipse.xtext.example.arithmetics/src/org/eclipse/xtext/example/arithmetics/GenerateArithmetics.mwe2
+++ b/org.eclipse.xpect.releng/xtext-examples/org.eclipse.xtext.example.arithmetics/src/org/eclipse/xtext/example/arithmetics/GenerateArithmetics.mwe2
@@ -52,6 +52,9 @@ Workflow {
 			validator = {
 				// composedCheck = "org.eclipse.xtext.validation.NamesAreUniqueValidator"
 			}
+			junitSupport = {
+				useDeprecatedClasses = true
+			}
 		}
 	}
 }


### PR DESCRIPTION
use old junit to work with newest xtext
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>