### PR TITLE
GH-264: Xpect files cannot be launched in IDE under Java 9

### DIFF
--- a/org.eclipse.xpect.releng/target-platforms/eclipse_4_10_0-xtext_nightly/org.eclipse.xpect.target.eclipse_4_10_0-xtext_nightly.target
+++ b/org.eclipse.xpect.releng/target-platforms/eclipse_4_10_0-xtext_nightly/org.eclipse.xpect.target.eclipse_4_10_0-xtext_nightly.target
@@ -27,6 +27,7 @@
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="io.github.classgraph" version="4.8.35.v20190528-1517"/>
+<unit id="io.github.classgraph.source" version="4.8.35.v20190528-1517"/>
 <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20190602212107/repository"/>
 </location>
 </locations>

--- a/org.eclipse.xpect.releng/target-platforms/eclipse_4_10_0-xtext_nightly/org.eclipse.xpect.target.eclipse_4_10_0-xtext_nightly.target
+++ b/org.eclipse.xpect.releng/target-platforms/eclipse_4_10_0-xtext_nightly/org.eclipse.xpect.target.eclipse_4_10_0-xtext_nightly.target
@@ -25,6 +25,10 @@
 <unit id="org.eclipse.sdk.ide" version="0.0.0"/>
 <repository location="http://download.eclipse.org/eclipse/updates/4.10"/>
 </location>
+<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="io.github.classgraph" version="4.8.35.v20190528-1517"/>
+<repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20190602212107/repository"/>
+</location>
 </locations>
 <environment>
 <nl>en_EN</nl>

--- a/org.eclipse.xpect.releng/target-platforms/eclipse_4_4_2-xtext_2_9_2/org.eclipse.xpect.target.eclipse_4_4_2-xtext_2_9_2.target
+++ b/org.eclipse.xpect.releng/target-platforms/eclipse_4_4_2-xtext_2_9_2/org.eclipse.xpect.target.eclipse_4_4_2-xtext_2_9_2.target
@@ -22,6 +22,10 @@
 <unit id="org.eclipse.sdk.ide" version="4.4.2.M20150204-1700"/>
 <repository location="http://download.eclipse.org/releases/luna/201502271000/"/>
 </location>
+<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="io.github.classgraph" version="4.8.35.v20190528-1517"/>
+<repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20190602212107/repository"/>
+</location>
 </locations>
 <environment>
 <nl>en_EN</nl>

--- a/org.eclipse.xpect.releng/target-platforms/eclipse_4_4_2-xtext_2_9_2/org.eclipse.xpect.target.eclipse_4_4_2-xtext_2_9_2.target
+++ b/org.eclipse.xpect.releng/target-platforms/eclipse_4_4_2-xtext_2_9_2/org.eclipse.xpect.target.eclipse_4_4_2-xtext_2_9_2.target
@@ -24,6 +24,7 @@
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="io.github.classgraph" version="4.8.35.v20190528-1517"/>
+<unit id="io.github.classgraph.source" version="4.8.35.v20190528-1517"/>
 <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20190602212107/repository"/>
 </location>
 </locations>

--- a/org.eclipse.xpect.releng/target-platforms/eclipse_4_5_0-xtext_2_14_0/org.eclipse.xpect.target.eclipse_4_5_0-xtext_2_14_0.target
+++ b/org.eclipse.xpect.releng/target-platforms/eclipse_4_5_0-xtext_2_14_0/org.eclipse.xpect.target.eclipse_4_5_0-xtext_2_14_0.target
@@ -27,6 +27,7 @@
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="io.github.classgraph" version="4.8.35.v20190528-1517"/>
+<unit id="io.github.classgraph.source" version="4.8.35.v20190528-1517"/>
 <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20190602212107/repository"/>
 </location>
 </locations>

--- a/org.eclipse.xpect.releng/target-platforms/eclipse_4_5_0-xtext_2_14_0/org.eclipse.xpect.target.eclipse_4_5_0-xtext_2_14_0.target
+++ b/org.eclipse.xpect.releng/target-platforms/eclipse_4_5_0-xtext_2_14_0/org.eclipse.xpect.target.eclipse_4_5_0-xtext_2_14_0.target
@@ -25,6 +25,10 @@
 <unit id="org.eclipse.sdk.ide" version="0.0.0"/>
 <repository location="http://download.eclipse.org/eclipse/updates/4.5/R-4.5.2-201602121500"/>
 </location>
+<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="io.github.classgraph" version="4.8.35.v20190528-1517"/>
+<repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20190602212107/repository"/>
+</location>
 </locations>
 <environment>
 <nl>en_EN</nl>

--- a/org.eclipse.xpect.xtext.lib.feature/feature.xml
+++ b/org.eclipse.xpect.xtext.lib.feature/feature.xml
@@ -76,6 +76,13 @@ Contributors:
          unpack="false"/>
 
    <plugin
+         id="io.github.classgraph"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
          id="org.junit"
          download-size="0"
          install-size="0"

--- a/org.eclipse.xpect.xtext.lib.feature/feature.xml
+++ b/org.eclipse.xpect.xtext.lib.feature/feature.xml
@@ -83,6 +83,13 @@ Contributors:
          unpack="false"/>
 
    <plugin
+         id="io.github.classgraph.source"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
          id="org.junit"
          download-size="0"
          install-size="0"

--- a/org.eclipse.xpect/META-INF/MANIFEST.MF
+++ b/org.eclipse.xpect/META-INF/MANIFEST.MF
@@ -25,7 +25,8 @@ Require-Bundle: org.apache.log4j;bundle-version="1.2.0";visibility:=reexport,
  org.eclipse.xtext.ecore;bundle-version="2.9.2";resolution:=optional,
  org.objectweb.asm;bundle-version="[3.0.0,8.0.0)";resolution:=optional,
  org.eclipse.equinox.common;bundle-version="3.0.0";resolution:=optional,
- org.eclipse.core.runtime;bundle-version="3.0.0";resolution:=optional
+ org.eclipse.core.runtime;bundle-version="3.0.0";resolution:=optional,
+ io.github.classgraph;bundle-version="4.8.35"
 Import-Package: org.apache.log4j
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.xpect,

--- a/org.eclipse.xpect/META-INF/MANIFEST.MF
+++ b/org.eclipse.xpect/META-INF/MANIFEST.MF
@@ -26,7 +26,7 @@ Require-Bundle: org.apache.log4j;bundle-version="1.2.0";visibility:=reexport,
  org.objectweb.asm;bundle-version="[3.0.0,8.0.0)";resolution:=optional,
  org.eclipse.equinox.common;bundle-version="3.0.0";resolution:=optional,
  org.eclipse.core.runtime;bundle-version="3.0.0";resolution:=optional,
- io.github.classgraph;bundle-version="4.8.35"
+ io.github.classgraph;bundle-version="4.8.35";visibility:=reexport
 Import-Package: org.apache.log4j
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.xpect,

--- a/org.eclipse.xpect/src/org/eclipse/xpect/util/ClasspathUtil.java
+++ b/org.eclipse.xpect/src/org/eclipse/xpect/util/ClasspathUtil.java
@@ -172,6 +172,9 @@ public class ClasspathUtil {
 				if (entry == null || entry.length() == 0) {
 					continue;
 				}
+				// Compare the following to the implementation of method
+				// jdk.internal.loader.URLClassPath#toFileURL(String) in
+				// JDK9 and later:
 				try {
 					File entryFile = new File(entry).getCanonicalFile();
 					URL entryURL = entryFile.toPath().toUri().toURL();


### PR DESCRIPTION
This PR contains the exact same changes as PR #265. All discussion / review happened there.

This PR was only created to fix issues with the eclipse/eca checker.