### PR TITLE
extended version range for ASM to prepare for Eclipse 2020-06 / Xtext 2.22

### DIFF
--- a/org.eclipse.xpect.releng/xtext-examples/org.eclipse.xtext.example.domainmodel.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xpect.releng/xtext-examples/org.eclipse.xtext.example.domainmodel.tests/META-INF/MANIFEST.MF
@@ -17,7 +17,7 @@ Require-Bundle: org.eclipse.xtext.example.domainmodel,
  org.hamcrest.core;bundle-version="1.1.0",
  org.eclipse.xtext.common.types.ui,
  org.eclipse.jdt.core;bundle-version="3.6.0",
- org.objectweb.asm;bundle-version="[5.0.1,8.0.0)";resolution:=optional,
+ org.objectweb.asm;bundle-version="[5.0.1,9.0.0)";resolution:=optional,
  org.eclipse.xtext.xbase.lib
 Import-Package: org.apache.commons.logging,
  org.apache.log4j;version="1.2.15",

--- a/org.eclipse.xpect.releng/xtext-examples/org.eclipse.xtext.example.domainmodel/META-INF/MANIFEST.MF
+++ b/org.eclipse.xpect.releng/xtext-examples/org.eclipse.xtext.example.domainmodel/META-INF/MANIFEST.MF
@@ -15,7 +15,7 @@ Require-Bundle: org.eclipse.xtext;visibility:=reexport,
  org.eclipse.xtext.common.types,
  org.eclipse.xtext.xbase.lib;visibility:=reexport,
  org.eclipse.xtext.ui.codetemplates,
- org.objectweb.asm;bundle-version="[5.0.1,8.0.0)";resolution:=optional,
+ org.objectweb.asm;bundle-version="[5.0.1,9.0.0)";resolution:=optional,
  org.eclipse.equinox.common,
  org.eclipse.xtext.generator,
  org.apache.commons.logging

--- a/org.eclipse.xpect.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xpect.tests/META-INF/MANIFEST.MF
@@ -13,7 +13,7 @@ Require-Bundle: org.eclipse.xpect,
  org.eclipse.xtend.lib,
  com.google.guava,
  org.eclipse.xtext.xbase.lib;bundle-version="2.9.2",
- org.objectweb.asm;bundle-version="[3.0.0,8.0.0)";resolution:=optional
+ org.objectweb.asm;bundle-version="[3.0.0,9.0.0)";resolution:=optional
 Import-Package: org.apache.log4j,
  org.junit;version="4.5.0",
  org.junit.runner;version="4.5.0",

--- a/org.eclipse.xpect/META-INF/MANIFEST.MF
+++ b/org.eclipse.xpect/META-INF/MANIFEST.MF
@@ -23,7 +23,7 @@ Require-Bundle: org.apache.log4j;bundle-version="1.2.0";visibility:=reexport,
  org.eclipse.emf.mwe2.launch;resolution:=optional,
  de.itemis.statefullexer;bundle-version="1.0.0";resolution:=optional,
  org.eclipse.xtext.ecore;bundle-version="2.9.2";resolution:=optional,
- org.objectweb.asm;bundle-version="[3.0.0,8.0.0)";resolution:=optional,
+ org.objectweb.asm;bundle-version="[3.0.0,9.0.0)";resolution:=optional,
  org.eclipse.equinox.common;bundle-version="3.0.0";resolution:=optional,
  org.eclipse.core.runtime;bundle-version="3.0.0";resolution:=optional,
  io.github.classgraph;bundle-version="4.8.35";visibility:=reexport


### PR DESCRIPTION
extended version range for ASM to prepare for Eclipse 2020-06 / Xtext 2.22

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>