### PR TITLE
GH-275: Update site broken

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@
 
 timestamps() {
     node() {
-        def mvnHome = tool 'apache-maven-3.0.5'
+        def mvnHome = tool 'apache-maven-3.2.5'
         def mvnParams = '--batch-mode --update-snapshots -fae -Dmaven.repo.local=xpect-local-maven-repository -DtestOnly=false'
         timeout(time: 1, unit: 'HOURS') {
             stage('prepare workspace') {


### PR DESCRIPTION
see #275 

updates version of apache-maven to 3.2.5, former version was 3.0.5 (see available versions at: https://wiki.eclipse.org/Jenkins#Apache_Maven).