### PR TITLE
GH-275B: Update site broken

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@
  *******************************************************************************/
 
 timestamps() {
-    node() {
+    node('ui-test') {
         def mvnHome = tool 'apache-maven-3.2.5'
         def mvnParams = '--batch-mode --update-snapshots -fae -Dmaven.repo.local=xpect-local-maven-repository -DtestOnly=false'
         timeout(time: 1, unit: 'HOURS') {


### PR DESCRIPTION
follow-up of https://github.com/eclipse/Xpect/pull/276

sets the Jenkins node label to 'ui-test' to support xvnc (more info here:
https://wiki.eclipse.org/Jenkins#How_do_I_run_UI-tests_on_the_new_infra.3F)

However, there are now eight test failures for `test with Eclipse 2018-12 and Xtext nighly`:
https://ci.eclipse.org/xpect/job/Xpect-Integration-Release/23/
Those can be resolved in another PR.
