### PR TITLE
added explicit dependency to xbase.lib as transitive is no longer there with newer xtext versions

### DIFF
--- a/org.eclipse.xpect/META-INF/MANIFEST.MF
+++ b/org.eclipse.xpect/META-INF/MANIFEST.MF
@@ -26,7 +26,8 @@ Require-Bundle: org.apache.log4j;bundle-version="1.2.0";visibility:=reexport,
  org.objectweb.asm;bundle-version="[3.0.0,9.0.0)";resolution:=optional,
  org.eclipse.equinox.common;bundle-version="3.0.0";resolution:=optional,
  org.eclipse.core.runtime;bundle-version="3.0.0";resolution:=optional,
- io.github.classgraph;bundle-version="4.8.35";visibility:=reexport
+ io.github.classgraph;bundle-version="4.8.35";visibility:=reexport,
+ org.eclipse.xtext.xbase.lib
 Import-Package: org.apache.log4j
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.xpect,


### PR DESCRIPTION
added explicit dependency to xbase.lib as transitive is no longer there with newer xtext versions

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>