### PR TITLE
Support update site promotion via a declarative Jenkins pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@ src-gen/
 xtend-gen/
 xtext-gen/
 target/
+/xpect/updates
 xpect-local-maven-repository

--- a/.project
+++ b/.project
@@ -8,4 +8,15 @@
 	</buildSpec>
 	<natures>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1697202706223</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-projectRelativePath-matches-false-true-org.eclipse.(xpect|xtext).*/.*</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,15 +1,23 @@
-Contributions are welcome.
+# Contributing to Eclipse Xpect
 
-## Eclipse Contributor Agreement
-Before your contribution can be accepted by the project team contributors must
-electronically sign the Eclipse Contributor Agreement (ECA).
+Thanks for your interest in this project.
 
-* http://www.eclipse.org/legal/ECA.php
+## Creating an Eclipse Development Environment
 
-Commits that are provided by non-committers must have a Signed-off-by field in
-the footer indicating that the author is aware of the terms by which the
-contribution has been provided to the project. The non-committer must
-additionally have an Eclipse Foundation account and must have a signed Eclipse
-Contributor Agreement (ECA) on file.
-For more information, please see the Eclipse Committer Handbook:
-https://www.eclipse.org/projects/handbook/#resources-commit
+You can set up a pre-configured IDE for the development of Xpect using the following link:
+
+[![Create Eclipse Development Environment for Xpect](https://download.eclipse.org/oomph/www/setups/svg/Xpect.svg)](https://www.eclipse.org/setups/installer/?url=https://raw.githubusercontent.com/eclipse/Xpect/master/org.eclipse.xpect.releng/XpectConfiguration.setup&show=true "Click to open Eclipse-Installer Auto Launch or drag onto your running installer's title area")
+
+
+
+## General Processes and Workflows
+
+The [eclipse-platform](https://github.com/eclipse-platform/.github/blob/main/CONTRIBUTING.md) provides detailed contribution information that is generally applicable also for Xpect.
+
+
+## Contact
+
+Contact the project developers via issues (preferred) or via "xpect-dev" mailing list.
+
+* https://github.com/eclipse/Xpect/issues
+* https://dev.eclipse.org/mailman/listinfo/xpect-dev

--- a/README.md
+++ b/README.md
@@ -1,27 +1,20 @@
-<!--
-Copyright (c) 2012-2017 TypeFox GmbH and itemis AG.
-This program and the accompanying materials are made
-available under the terms of the Eclipse Public License 2.0
-which is available at https://www.eclipse.org/legal/epl-2.0/
-SPDX-License-Identifier: EPL-2.0
+# Eclipse Xpect
 
-Contributors:
-  Moritz Eysholdt - Initial contribution and API
--->
-
-# Xpect
-
-A unit- and integration-testing framework that stores test data in any kind of text files and is based on JUnit. 
+Xpect&trade; is a unit- and integration-testing framework that stores test data in any kind of text files and is based on JUnit. 
 The core focus of Xpect is on testing Xtext languages and supporting the process of designing Xtext languages.
 
+## Documentation
 
-## Installation further Information
-
-Go to http://www.xpect-tests.org (and look for an Eclipse update-site).
+Visit [xpect-tests.org](http://www.xpect-tests.org) for details.
 
 #### Nightly builds
 
 Use Jenkins https://ci.eclipse.org/xpect/job/Xpect/job/master/lastSuccessfulBuild/artifact/org.eclipse.xpect.releng/p2-repository/target/repository/
+
+
+# Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
 
 ## Compile and Build Xpect by Yourself
 
@@ -32,6 +25,3 @@ Prerequisite: Java 11 or newer; Eclipse (2023-03 or newer recommended); Xtext 2.
  3. Set target platform to /org.eclipse.xpect.releng/target-platforms/eclipse_2023_03-xtext_2_31_0/org.eclipse.xpect.target.eclipse_2023_03-xtext_2_31_0.target (Preferences -> Plug-in Development -> Target Platform)
  4. Run /org.eclipse.xpect/src/org/eclipse/xpect/GenerateXpect.mwe2, /org.xtext.example.arithmetics/src/org/eclipse/xpect/example/arithmetics/GenerateXpect.mwe2, /org.xtext.example.domainmodel/src/org/xtext/example/domainmodel/GenerateDomainmodel.mwe2. Now your projects should be without errors markers. Sometimes, even after these steps, several projects still have error markers. However, this is a refresh problem in Eclipse. Simply clean build the projects with error markers will solve the issues.
  5. Run `mvn -P '!tests'  -Dtarget-platform=eclipse_2023_03-xtext_2_31_0 --batch-mode --update-snapshots -fae -Dmaven.repo.local=xpect-local-maven-repository -DtestOnly=false clean install` to build artefacts and create a p2 repository (formerly known as update site).
-
-
- 

--- a/org.eclipse.xpect.doc/META-INF/MANIFEST.MF
+++ b/org.eclipse.xpect.doc/META-INF/MANIFEST.MF
@@ -1,8 +1,9 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Doc
-Bundle-SymbolicName: org.eclipse.xpect.doc
+Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
+Bundle-SymbolicName: org.eclipse.xpect.doc
+Bundle-Localization: plugin
 Bundle-Version: 1.0.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.xtext;bundle-version="2.4.0",

--- a/org.eclipse.xpect.doc/plugin.properties
+++ b/org.eclipse.xpect.doc/plugin.properties
@@ -1,3 +1,3 @@
 
-pluginName = org.eclipse.xpect.doc
-providerName = Eclipse Xpect Project
+pluginName = Xpect Documentation
+providerName = Eclipse Xpect

--- a/org.eclipse.xpect.examples/META-INF/MANIFEST.MF
+++ b/org.eclipse.xpect.examples/META-INF/MANIFEST.MF
@@ -1,8 +1,9 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Examples
-Bundle-SymbolicName: org.eclipse.xpect.examples
+Bundle-Name: %pluginName
+Bundle-Localization: plugin
 Bundle-Vendor: %providerName
+Bundle-SymbolicName: org.eclipse.xpect.examples
 Bundle-Version: 1.0.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.xtend.lib,

--- a/org.eclipse.xpect.examples/plugin.properties
+++ b/org.eclipse.xpect.examples/plugin.properties
@@ -1,3 +1,3 @@
 
-pluginName = org.eclipse.xpect.examples
-providerName = Eclipse Xpect Project
+pluginName = Xpect Examples
+providerName = Eclipse Xpect

--- a/org.eclipse.xpect.ide/META-INF/MANIFEST.MF
+++ b/org.eclipse.xpect.ide/META-INF/MANIFEST.MF
@@ -1,8 +1,8 @@
 Manifest-Version: 1.0
 Automatic-Module-Name: org.eclipse.xpect.ide
 Bundle-ManifestVersion: 2
-Bundle-Name: org.eclipse.xpect.ide
-Bundle-Vendor: %providerName
+Bundle-Name: Xpect IDE
+Bundle-Vendor: Eclipse Xpect Project
 Bundle-Version: 0.3.0.qualifier
 Bundle-SymbolicName: org.eclipse.xpect.ide; singleton:=true
 Bundle-ActivationPolicy: lazy

--- a/org.eclipse.xpect.mwe2/.classpath
+++ b/org.eclipse.xpect.mwe2/.classpath
@@ -7,6 +7,11 @@
 			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins">
+		<accessrules>
+			<accessrule kind="accessible" pattern="org/eclipse/xtext/grammaranalysis/**"/>
+			<accessrule kind="accessible" pattern="org/eclipse/xtext/util/formallang/**"/>
+		</accessrules>
+	</classpathentry>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/org.eclipse.xpect.mwe2/META-INF/MANIFEST.MF
+++ b/org.eclipse.xpect.mwe2/META-INF/MANIFEST.MF
@@ -1,8 +1,9 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Lib
-Bundle-SymbolicName: org.eclipse.xpect.mwe2
+Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
+Bundle-Localization: plugin
+Bundle-SymbolicName: org.eclipse.xpect.mwe2
 Bundle-Version: 0.3.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Automatic-Module-Name: org.eclipse.xpect.xtext.lib

--- a/org.eclipse.xpect.mwe2/build.properties
+++ b/org.eclipse.xpect.mwe2/build.properties
@@ -1,6 +1,7 @@
 source.. = src/,\
            xtend-gen/
 bin.includes = .,\
-               META-INF/
+               META-INF/,\
+               plugin.properties
 bin.excludes = **/*.xtend
 additional.bundles = org.eclipse.xtext.xtext.generator

--- a/org.eclipse.xpect.mwe2/plugin.properties
+++ b/org.eclipse.xpect.mwe2/plugin.properties
@@ -1,3 +1,3 @@
 
-pluginName = org.eclipse.xpect.mwe2
-providerName = Eclipse Xpect Project
+pluginName = Xpect MWE2
+providerName = Eclipse Xpect

--- a/org.eclipse.xpect.mwe2/src/org/eclipse/xpect/mwe2/statefullexer/GroupingTraverser.java
+++ b/org.eclipse.xpect.mwe2/src/org/eclipse/xpect/mwe2/statefullexer/GroupingTraverser.java
@@ -14,7 +14,6 @@ package org.eclipse.xpect.mwe2.statefullexer;
 import org.eclipse.xtext.util.formallang.DirectedGraph;
 import org.eclipse.xtext.util.formallang.Traverser;
 
-@SuppressWarnings("restriction")
 public interface GroupingTraverser<DG extends DirectedGraph<S>, S, R, G> extends Traverser<DG, S, R> {
 
 	G getGroup(R result);

--- a/org.eclipse.xpect.mwe2/src/org/eclipse/xpect/mwe2/statefullexer/NfaToDot2.java
+++ b/org.eclipse.xpect.mwe2/src/org/eclipse/xpect/mwe2/statefullexer/NfaToDot2.java
@@ -16,7 +16,6 @@ import org.eclipse.xtext.util.formallang.NfaUtil;
 
 import com.google.common.base.Functions;
 
-@SuppressWarnings("restriction")
 public class NfaToDot2 extends GraphvizDotBuilder2 {
 
 	protected Edge create(Props result, Nfa<Object> nfa, Object from, Object to) {

--- a/org.eclipse.xpect.mwe2/src/org/eclipse/xpect/mwe2/statefullexer/NfaUtil2.java
+++ b/org.eclipse.xpect.mwe2/src/org/eclipse/xpect/mwe2/statefullexer/NfaUtil2.java
@@ -45,7 +45,6 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 
-@SuppressWarnings("restriction")
 public class NfaUtil2 {
 
 	protected static class GroupingTraversalItem<S, R, G> {

--- a/org.eclipse.xpect.mwe2/src/org/eclipse/xpect/mwe2/statefullexer/NfaWithAllStates.java
+++ b/org.eclipse.xpect.mwe2/src/org/eclipse/xpect/mwe2/statefullexer/NfaWithAllStates.java
@@ -13,7 +13,6 @@ package org.eclipse.xpect.mwe2.statefullexer;
 
 import org.eclipse.xtext.util.formallang.Nfa;
 
-@SuppressWarnings("restriction")
 public interface NfaWithAllStates<STATE> extends Nfa<STATE> {
 	Iterable<STATE> getAllStates();
 }

--- a/org.eclipse.xpect.mwe2/src/org/eclipse/xpect/mwe2/statefullexer/NfaWithGroups.java
+++ b/org.eclipse.xpect.mwe2/src/org/eclipse/xpect/mwe2/statefullexer/NfaWithGroups.java
@@ -14,7 +14,6 @@ package org.eclipse.xpect.mwe2.statefullexer;
 import org.eclipse.xtext.util.formallang.Nfa;
 import org.eclipse.xtext.util.formallang.NfaFactory;
 
-@SuppressWarnings("restriction")
 public interface NfaWithGroups<GROUP, STATE> extends Nfa<STATE> {
 	public interface NfaWithGroupsFactory<NFA extends Nfa<STATE>, GROUP, STATE, TOKEN> extends NfaFactory<NFA, STATE, TOKEN> {
 		void setGroup(NFA nfa, GROUP group, STATE state);

--- a/org.eclipse.xpect.mwe2/src/org/eclipse/xpect/mwe2/statefullexer/NfaWithTransitions.java
+++ b/org.eclipse.xpect.mwe2/src/org/eclipse/xpect/mwe2/statefullexer/NfaWithTransitions.java
@@ -13,7 +13,6 @@ package org.eclipse.xpect.mwe2.statefullexer;
 
 import org.eclipse.xtext.util.formallang.Nfa;
 
-@SuppressWarnings("restriction")
 public interface NfaWithTransitions<STATE, TRANSITION> extends Nfa<STATE> {
 
 	Iterable<TRANSITION> getOutgoingTransitions(STATE state);

--- a/org.eclipse.xpect.mwe2/src/org/eclipse/xpect/mwe2/statefullexer/PdaUtil2.java
+++ b/org.eclipse.xpect.mwe2/src/org/eclipse/xpect/mwe2/statefullexer/PdaUtil2.java
@@ -25,7 +25,6 @@ import com.google.common.base.Function;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
 
-@SuppressWarnings("restriction")
 public class PdaUtil2 extends PdaUtil {
 	protected <S, P, E, T1, T2, D extends Pda<S, P>> void create(Cfg<E, T1> cfg, D pda, S state, E ele, Iterable<E> followerElements, boolean canEnter,
 			FollowerFunction<E> ff, Function<E, T2> tokens, PdaFactory<D, S, P, ? super T2> fact, Map<E, S> states, Map<E, S> stops, Multimap<E, E> callers) {

--- a/org.eclipse.xpect.mwe2/src/org/eclipse/xpect/mwe2/statefullexer/TokenNFA.java
+++ b/org.eclipse.xpect.mwe2/src/org/eclipse/xpect/mwe2/statefullexer/TokenNFA.java
@@ -19,7 +19,6 @@ import org.eclipse.xtext.util.formallang.NfaFactory;
 
 import com.google.common.base.Function;
 
-@SuppressWarnings("restriction")
 public class TokenNFA<T> implements Nfa<TokenNfaState<T>> {
 
 	public enum NFAStateType {

--- a/org.eclipse.xpect.mwe2/src/org/eclipse/xpect/mwe2/statefullexer/TokenPDA.java
+++ b/org.eclipse.xpect.mwe2/src/org/eclipse/xpect/mwe2/statefullexer/TokenPDA.java
@@ -19,7 +19,6 @@ import org.eclipse.xtext.util.formallang.PdaFactory;
 
 import com.google.common.base.Function;
 
-@SuppressWarnings("restriction")
 public class TokenPDA<T, S> implements Pda<TokenPDAState<T>, S> {
 
 	public enum PDAStateType {

--- a/org.eclipse.xpect.releng/Xpect - clean.launch
+++ b/org.eclipse.xpect.releng/Xpect - clean.launch
@@ -14,9 +14,11 @@
     <stringAttribute key="M2_USER_SETTINGS" value=""/>
     <booleanAttribute key="M2_WORKSPACE_RESOLUTION" value="false"/>
     <booleanAttribute key="org.eclipse.debug.core.ATTR_FORCE_SYSTEM_CONSOLE_ENCODING" value="false"/>
+    <stringAttribute key="org.eclipse.debug.core.ATTR_REFRESH_SCOPE" value="${workspace}"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_ATTR_USE_ARGFILE" value="false"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_SHOW_CODEDETAILS_IN_EXCEPTION_MESSAGES" value="true"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_CLASSPATH_ONLY_JAR" value="false"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
-    <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11/"/>
+    <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17/"/>
     <stringAttribute key="org.eclipse.jdt.launching.WORKING_DIRECTORY" value="${workspace_loc:/org.eclipse.xpect.releng}/../"/>
 </launchConfiguration>

--- a/org.eclipse.xpect.releng/Xpect - install and test.launch
+++ b/org.eclipse.xpect.releng/Xpect - install and test.launch
@@ -5,18 +5,22 @@
     <stringAttribute key="M2_GOALS" value="clean install"/>
     <booleanAttribute key="M2_NON_RECURSIVE" value="false"/>
     <booleanAttribute key="M2_OFFLINE" value="false"/>
-    <stringAttribute key="M2_PROFILES" value=""/>
-    <listAttribute key="M2_PROPERTIES"/>
+    <stringAttribute key="M2_PROFILES" value="!promote"/>
+    <listAttribute key="M2_PROPERTIES">
+        <listEntry value="target-platform=eclipse_2023_03-xtext_2_31_0"/>
+    </listAttribute>
     <stringAttribute key="M2_RUNTIME" value="EMBEDDED"/>
     <booleanAttribute key="M2_SKIP_TESTS" value="false"/>
     <intAttribute key="M2_THREADS" value="1"/>
-    <booleanAttribute key="M2_UPDATE_SNAPSHOTS" value="false"/>
+    <booleanAttribute key="M2_UPDATE_SNAPSHOTS" value="true"/>
     <stringAttribute key="M2_USER_SETTINGS" value=""/>
     <booleanAttribute key="M2_WORKSPACE_RESOLUTION" value="false"/>
     <booleanAttribute key="org.eclipse.debug.core.ATTR_FORCE_SYSTEM_CONSOLE_ENCODING" value="false"/>
+    <stringAttribute key="org.eclipse.debug.core.ATTR_REFRESH_SCOPE" value="${workspace}"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_ATTR_USE_ARGFILE" value="false"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_SHOW_CODEDETAILS_IN_EXCEPTION_MESSAGES" value="true"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_CLASSPATH_ONLY_JAR" value="false"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
-    <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11/"/>
+    <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17/"/>
     <stringAttribute key="org.eclipse.jdt.launching.WORKING_DIRECTORY" value="${workspace_loc:/org.eclipse.xpect.releng}/../"/>
 </launchConfiguration>

--- a/org.eclipse.xpect.releng/Xpect - promote.launch
+++ b/org.eclipse.xpect.releng/Xpect - promote.launch
@@ -7,20 +7,21 @@
     <booleanAttribute key="M2_OFFLINE" value="false"/>
     <stringAttribute key="M2_PROFILES" value=""/>
     <listAttribute key="M2_PROPERTIES">
-        <listEntry value="target_p2_repository=/../../../Xpect_pages/updatesite/nightly/local"/>
         <listEntry value="target-platform=eclipse_2023_03-xtext_2_31_0"/>
+        <listEntry value="org.eclipse.justj.p2.manager.remote=localhost:${project_loc:/Xpect}/xpect"/>
     </listAttribute>
     <stringAttribute key="M2_RUNTIME" value="EMBEDDED"/>
-    <booleanAttribute key="M2_SKIP_TESTS" value="false"/>
+    <booleanAttribute key="M2_SKIP_TESTS" value="true"/>
     <intAttribute key="M2_THREADS" value="1"/>
-    <booleanAttribute key="M2_UPDATE_SNAPSHOTS" value="false"/>
+    <booleanAttribute key="M2_UPDATE_SNAPSHOTS" value="true"/>
     <stringAttribute key="M2_USER_SETTINGS" value=""/>
     <booleanAttribute key="M2_WORKSPACE_RESOLUTION" value="false"/>
     <booleanAttribute key="org.eclipse.debug.core.ATTR_FORCE_SYSTEM_CONSOLE_ENCODING" value="false"/>
+    <stringAttribute key="org.eclipse.debug.core.ATTR_REFRESH_SCOPE" value="${workspace}"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_ATTR_USE_ARGFILE" value="false"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_SHOW_CODEDETAILS_IN_EXCEPTION_MESSAGES" value="true"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_CLASSPATH_ONLY_JAR" value="false"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
-    <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11/"/>
-    <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Xmx4096m"/>
+    <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17/"/>
     <stringAttribute key="org.eclipse.jdt.launching.WORKING_DIRECTORY" value="${workspace_loc:/org.eclipse.xpect.releng}/../"/>
 </launchConfiguration>

--- a/org.eclipse.xpect.releng/Xpect.setup
+++ b/org.eclipse.xpect.releng/Xpect.setup
@@ -1,0 +1,438 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<setup:Project
+    xmi:version="2.0"
+    xmlns:xmi="http://www.omg.org/XMI"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:git="http://www.eclipse.org/oomph/setup/git/1.0"
+    xmlns:jdt="http://www.eclipse.org/oomph/setup/jdt/1.0"
+    xmlns:launching="http://www.eclipse.org/oomph/setup/launching/1.0"
+    xmlns:predicates="http://www.eclipse.org/oomph/predicates/1.0"
+    xmlns:setup="http://www.eclipse.org/oomph/setup/1.0"
+    xmlns:setup.p2="http://www.eclipse.org/oomph/setup/p2/1.0"
+    xmlns:setup.targlets="http://www.eclipse.org/oomph/setup/targlets/1.0"
+    xmlns:setup.workingsets="http://www.eclipse.org/oomph/setup/workingsets/1.0"
+    xmlns:workingsets="http://www.eclipse.org/oomph/workingsets/1.0"
+    xsi:schemaLocation="http://www.eclipse.org/oomph/setup/git/1.0 https://raw.githubusercontent.com/eclipse-oomph/oomph/master/setups/models/Git.ecore http://www.eclipse.org/oomph/setup/jdt/1.0 https://raw.githubusercontent.com/eclipse-oomph/oomph/master/setups/models/JDT.ecore http://www.eclipse.org/oomph/setup/launching/1.0 https://raw.githubusercontent.com/eclipse-oomph/oomph/master/setups/models/Launching.ecore http://www.eclipse.org/oomph/predicates/1.0 https://raw.githubusercontent.com/eclipse-oomph/oomph/master/setups/models/Predicates.ecore http://www.eclipse.org/oomph/setup/targlets/1.0 https://raw.githubusercontent.com/eclipse-oomph/oomph/master/setups/models/SetupTarglets.ecore http://www.eclipse.org/oomph/setup/workingsets/1.0 https://raw.githubusercontent.com/eclipse-oomph/oomph/master/setups/models/SetupWorkingSets.ecore http://www.eclipse.org/oomph/workingsets/1.0 https://raw.githubusercontent.com/eclipse-oomph/oomph/master/setups/models/WorkingSets.ecore"
+    name="xpect"
+    label="Xpect">
+  <annotation
+      source="http://www.eclipse.org/oomph/setup/ConfigurationReference">
+    <reference
+        href="XpectConfiguration.setup#/"/>
+  </annotation>
+  <setupTask
+      xsi:type="setup:CompoundTask"
+      name="User Preferences">
+    <annotation
+        source="http://www.eclipse.org/oomph/setup/UserPreferences">
+      <detail
+          key="/instance/org.eclipse.core.runtime/line.separator">
+        <value>record</value>
+      </detail>
+      <detail
+          key="/instance/org.eclipse.oomph.setup.ui/showToolBarContributions">
+        <value>record</value>
+      </detail>
+      <detail
+          key="/instance/org.eclipse.jdt.launching/org.eclipse.jdt.launching.PREF_STRICTLY_COMPATIBLE_JRE_NOT_AVAILABLE">
+        <value>record</value>
+      </detail>
+      <detail
+          key="/instance/org.eclipse.pde/compilers.p.exec-env-too-low">
+        <value>record</value>
+      </detail>
+      <detail
+          key="/instance/org.eclipse.jdt.launching/org.eclipse.jdt.launching.PREF_COMPILER_COMPLIANCE_DOES_NOT_MATCH_JRE">
+        <value>record</value>
+      </detail>
+      <detail
+          key="/instance/org.eclipse.pde/compilers.p.deprecated">
+        <value>record</value>
+      </detail>
+      <detail
+          key="/instance/org.eclipse.pde/compilers.p.discouraged-class">
+        <value>record</value>
+      </detail>
+    </annotation>
+    <setupTask
+        xsi:type="setup:CompoundTask"
+        name="org.eclipse.core.runtime">
+      <setupTask
+          xsi:type="setup:PreferenceTask"
+          key="/instance/org.eclipse.core.runtime/line.separator"
+          value="&#xA;"/>
+    </setupTask>
+    <setupTask
+        xsi:type="setup:CompoundTask"
+        name="org.eclipse.jdt.launching">
+      <setupTask
+          xsi:type="setup:PreferenceTask"
+          key="/instance/org.eclipse.jdt.launching/org.eclipse.jdt.launching.PREF_COMPILER_COMPLIANCE_DOES_NOT_MATCH_JRE"
+          value="ignore"/>
+      <setupTask
+          xsi:type="setup:PreferenceTask"
+          key="/instance/org.eclipse.jdt.launching/org.eclipse.jdt.launching.PREF_STRICTLY_COMPATIBLE_JRE_NOT_AVAILABLE"
+          value="ignore"/>
+    </setupTask>
+    <setupTask
+        xsi:type="setup:CompoundTask"
+        name="org.eclipse.oomph.setup.ui">
+      <setupTask
+          xsi:type="setup:PreferenceTask"
+          key="/instance/org.eclipse.oomph.setup.ui/showToolBarContributions"
+          value="true"/>
+    </setupTask>
+    <setupTask
+        xsi:type="setup:CompoundTask"
+        name="org.eclipse.pde">
+      <setupTask
+          xsi:type="setup:PreferenceTask"
+          key="/instance/org.eclipse.pde/compilers.p.deprecated"
+          value="2"/>
+      <setupTask
+          xsi:type="setup:PreferenceTask"
+          key="/instance/org.eclipse.pde/compilers.p.discouraged-class"
+          value="2"/>
+      <setupTask
+          xsi:type="setup:PreferenceTask"
+          key="/instance/org.eclipse.pde/compilers.p.exec-env-too-low"
+          value="2"/>
+    </setupTask>
+    <setupTask
+        xsi:type="setup:CompoundTask"
+        name="User Preferences">
+      <annotation
+          source="http://www.eclipse.org/oomph/setup/UserPreferences">
+        <detail
+            key="/instance/org.eclipse.core.runtime/line.separator">
+          <value>record</value>
+        </detail>
+        <detail
+            key="/instance/org.eclipse.oomph.setup.ui/showToolBarContributions">
+          <value>record</value>
+        </detail>
+        <detail
+            key="/instance/org.eclipse.jdt.launching/org.eclipse.jdt.launching.PREF_STRICTLY_COMPATIBLE_JRE_NOT_AVAILABLE">
+          <value>record</value>
+        </detail>
+        <detail
+            key="/instance/org.eclipse.pde/compilers.p.exec-env-too-low">
+          <value>record</value>
+        </detail>
+        <detail
+            key="/instance/org.eclipse.jdt.launching/org.eclipse.jdt.launching.PREF_COMPILER_COMPLIANCE_DOES_NOT_MATCH_JRE">
+          <value>record</value>
+        </detail>
+      </annotation>
+      <setupTask
+          xsi:type="setup:CompoundTask"
+          name="org.eclipse.core.runtime">
+        <setupTask
+            xsi:type="setup:PreferenceTask"
+            key="/instance/org.eclipse.core.runtime/line.separator"
+            value="&#xA;"/>
+      </setupTask>
+      <setupTask
+          xsi:type="setup:CompoundTask"
+          name="org.eclipse.jdt.launching">
+        <setupTask
+            xsi:type="setup:PreferenceTask"
+            key="/instance/org.eclipse.jdt.launching/org.eclipse.jdt.launching.PREF_COMPILER_COMPLIANCE_DOES_NOT_MATCH_JRE"
+            value="ignore"/>
+        <setupTask
+            xsi:type="setup:PreferenceTask"
+            key="/instance/org.eclipse.jdt.launching/org.eclipse.jdt.launching.PREF_STRICTLY_COMPATIBLE_JRE_NOT_AVAILABLE"
+            value="ignore"/>
+      </setupTask>
+      <setupTask
+          xsi:type="setup:CompoundTask"
+          name="org.eclipse.oomph.setup.ui">
+        <setupTask
+            xsi:type="setup:PreferenceTask"
+            key="/instance/org.eclipse.oomph.setup.ui/showToolBarContributions"
+            value="true"/>
+      </setupTask>
+      <setupTask
+          xsi:type="setup:CompoundTask"
+          name="org.eclipse.pde">
+        <setupTask
+            xsi:type="setup:PreferenceTask"
+            key="/instance/org.eclipse.pde/compilers.p.exec-env-too-low"
+            value="2"/>
+      </setupTask>
+    </setupTask>
+  </setupTask>
+  <setupTask
+      xsi:type="jdt:JRETask"
+      version="JavaSE-17"
+      location="${jre.location-17}"
+      name="JRE for JavaSE-17">
+    <description>Define the JRE needed to compile and run the Java projects of ${scope.project.label}</description>
+  </setupTask>
+  <setupTask
+      xsi:type="setup:EclipseIniTask"
+      option="-Xmx"
+      value="2048m"
+      vm="true">
+    <description>Set the heap space needed to work with the projects of ${scope.project.label}</description>
+  </setupTask>
+  <setupTask
+      xsi:type="setup:VariableTask"
+      name="eclipse.target.platform"
+      defaultValue="${eclipse.target.platform.latest}"
+      storageURI="scope://Workspace"/>
+  <setupTask
+      xsi:type="setup:VariableTask"
+      name="xtext.latest.release.url"
+      value="https://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.32.0">
+    <description>The p2 update site URL for the last Xtext release.</description>
+  </setupTask>
+  <setupTask
+      xsi:type="setup:VariableTask"
+      name="mwe.latest.release.url"
+      value="https://download.eclipse.org/modeling/emft/mwe/updates/releases/2.15.0">
+    <description>The p2 update site URL for the last MWE release.</description>
+  </setupTask>
+  <setupTask
+      xsi:type="setup.p2:P2Task"
+      label="Xtext">
+    <requirement
+        name="org.eclipse.xtext.sdk.feature.group"/>
+    <requirement
+        name="org.eclipse.xtend.sdk.feature.group"/>
+    <requirement
+        name="org.eclipse.m2e.feature.feature.group"/>
+    <requirement
+        name="org.eclipse.m2e.pde.feature.feature.group"/>
+    <requirement
+        name="org.eclipse.emf.sdk.feature.group"/>
+    <repository
+        url="${xtext.latest.release.url}"/>
+    <repository
+        url="${mwe.latest.release.url}"/>
+    <repository
+        url="https://download.eclipse.org/releases/${eclipse.target.platform}"/>
+  </setupTask>
+  <setupTask
+      xsi:type="setup:ResourceCreationTask"
+      excludedTriggers="STARTUP MANUAL"
+      targetURL="${workspace.location|uri}/.metadata/.plugins/org.eclipse.jdt.ui/dialog_settings.xml"
+      encoding="UTF-8">
+    <description>Initialize JDT's package explorer to show working sets as its root objects</description>
+    <content>
+      &lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?>
+      &lt;section name=&quot;Workbench&quot;>
+      	&lt;section name=&quot;org.eclipse.jdt.internal.ui.packageview.PackageExplorerPart&quot;>
+      		&lt;item value=&quot;true&quot; key=&quot;group_libraries&quot;/>
+      		&lt;item value=&quot;false&quot; key=&quot;linkWithEditor&quot;/>
+      		&lt;item value=&quot;2&quot; key=&quot;layout&quot;/>
+      		&lt;item value=&quot;2&quot; key=&quot;rootMode&quot;/>
+      		&lt;item value=&quot;&amp;lt;?xml version=&amp;quot;1.0&amp;quot; encoding=&amp;quot;UTF-8&amp;quot;?&amp;gt;&amp;#x0D;&amp;#x0A;&amp;lt;packageExplorer configured=&amp;quot;true&amp;quot; group_libraries=&amp;quot;1&amp;quot; layout=&amp;quot;2&amp;quot; linkWithEditor=&amp;quot;0&amp;quot; rootMode=&amp;quot;2&amp;quot; sortWorkingSets=&amp;quot;false&amp;quot; workingSetName=&amp;quot;&amp;quot;&amp;gt;&amp;#x0D;&amp;#x0A;&amp;lt;localWorkingSetManager&amp;gt;&amp;#x0D;&amp;#x0A;&amp;lt;workingSet editPageId=&amp;quot;org.eclipse.jdt.internal.ui.OthersWorkingSet&amp;quot; factoryID=&amp;quot;org.eclipse.ui.internal.WorkingSetFactory&amp;quot; id=&amp;quot;1382792884467_1&amp;quot; label=&amp;quot;Other Projects&amp;quot; name=&amp;quot;Other Projects&amp;quot;/&amp;gt;&amp;#x0D;&amp;#x0A;&amp;lt;/localWorkingSetManager&amp;gt;&amp;#x0D;&amp;#x0A;&amp;lt;activeWorkingSet workingSetName=&amp;quot;Other Projects&amp;quot;/&amp;gt;&amp;#x0D;&amp;#x0A;&amp;lt;allWorkingSets workingSetName=&amp;quot;Other Projects&amp;quot;/&amp;gt;&amp;#x0D;&amp;#x0A;&amp;lt;/packageExplorer&amp;gt;&quot; key=&quot;memento&quot;/>
+      	&lt;/section>
+      &lt;/section>
+
+    </content>
+  </setupTask>
+  <setupTask
+      xsi:type="setup:ResourceCreationTask"
+      excludedTriggers="STARTUP MANUAL"
+      force="true"
+      targetURL="${workspace.location|uri}/.metadata/.plugins/org.eclipse.debug.core/.launches/Xpect-generate.launch"
+      encoding="UTF-8">
+    <description>Initialize JDT's package explorer to show working sets as its root objects</description>
+    <content>
+      &lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?>
+      &lt;launchConfiguration type=&quot;org.eclipse.m2e.Maven2LaunchConfigurationType&quot;>
+          &lt;intAttribute key=&quot;M2_COLORS&quot; value=&quot;0&quot;/>
+          &lt;booleanAttribute key=&quot;M2_DEBUG_OUTPUT&quot; value=&quot;false&quot;/>
+          &lt;stringAttribute key=&quot;M2_GOALS&quot; value=&quot;clean verify&quot;/>
+          &lt;booleanAttribute key=&quot;M2_NON_RECURSIVE&quot; value=&quot;false&quot;/>
+          &lt;booleanAttribute key=&quot;M2_OFFLINE&quot; value=&quot;false&quot;/>
+          &lt;stringAttribute key=&quot;M2_PROFILES&quot; value=&quot;!promote&quot;/>
+          &lt;listAttribute key=&quot;M2_PROPERTIES&quot;>
+              &lt;listEntry value=&quot;target-platform=eclipse_2023_03-xtext_2_31_0&quot;/>
+              &lt;listEntry value=&quot;user.home=$${system_property:user.home}&quot;/>
+              &lt;listEntry value=&quot;tycho-version=4.0.3&quot;/>
+          &lt;/listAttribute>
+          &lt;stringAttribute key=&quot;M2_RUNTIME&quot; value=&quot;EMBEDDED&quot;/>
+          &lt;booleanAttribute key=&quot;M2_SKIP_TESTS&quot; value=&quot;true&quot;/>
+          &lt;intAttribute key=&quot;M2_THREADS&quot; value=&quot;1&quot;/>
+          &lt;booleanAttribute key=&quot;M2_UPDATE_SNAPSHOTS&quot; value=&quot;true&quot;/>
+          &lt;stringAttribute key=&quot;M2_USER_SETTINGS&quot; value=&quot;&quot;/>
+          &lt;booleanAttribute key=&quot;M2_WORKSPACE_RESOLUTION&quot; value=&quot;false&quot;/>
+          &lt;booleanAttribute key=&quot;org.eclipse.debug.core.ATTR_FORCE_SYSTEM_CONSOLE_ENCODING&quot; value=&quot;false&quot;/>
+          &lt;stringAttribute key=&quot;org.eclipse.debug.core.ATTR_REFRESH_SCOPE&quot; value=&quot;$${workspace}&quot;/>
+          &lt;booleanAttribute key=&quot;org.eclipse.jdt.launching.ATTR_ATTR_USE_ARGFILE&quot; value=&quot;false&quot;/>
+          &lt;booleanAttribute key=&quot;org.eclipse.jdt.launching.ATTR_SHOW_CODEDETAILS_IN_EXCEPTION_MESSAGES&quot; value=&quot;true&quot;/>
+          &lt;booleanAttribute key=&quot;org.eclipse.jdt.launching.ATTR_USE_CLASSPATH_ONLY_JAR&quot; value=&quot;false&quot;/>
+          &lt;booleanAttribute key=&quot;org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD&quot; value=&quot;true&quot;/>
+          &lt;stringAttribute key=&quot;org.eclipse.jdt.launching.JRE_CONTAINER&quot; value=&quot;org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17/&quot;/>
+          &lt;stringAttribute key=&quot;org.eclipse.jdt.launching.WORKING_DIRECTORY&quot; value=&quot;${git.clone.xpect.location}&quot;/>
+      &lt;/launchConfiguration>
+
+    </content>
+  </setupTask>
+  <setupTask
+      xsi:type="git:GitCloneTask"
+      id="git.clone.xpect"
+      remoteURI="eclipse/Xpect">
+    <annotation
+        source="http://www.eclipse.org/oomph/setup/InducedChoices">
+      <detail
+          key="inherit">
+        <value>github.remoteURIs</value>
+      </detail>
+      <detail
+          key="label">
+        <value>${scope.project.label} GitHub repository</value>
+      </detail>
+      <detail
+          key="target">
+        <value>remoteURI</value>
+      </detail>
+    </annotation>
+    <configSections
+        name="core">
+      <properties
+          key="autocrlf"
+          value="input"/>
+    </configSections>
+    <description>${scope.project.label}</description>
+  </setupTask>
+  <setupTask
+      xsi:type="launching:LaunchTask"
+      launcher="Xpect-generate"/>
+  <setupTask
+      xsi:type="setup.targlets:TargletTask">
+    <targlet
+        name="Xpect">
+      <requirement
+          name="*"/>
+      <requirement
+          name="org.eclipse.sdk.feature.group"/>
+      <requirement
+          name="org.eclipse.xtext.sdk.feature.group"/>
+      <requirement
+          name="org.eclipse.xtend.sdk.feature.group"/>
+      <requirement
+          name="org.eclipse.xtext.xtext.generator"/>
+      <sourceLocator
+          rootFolder="${git.clone.xpect.location}"
+          locateNestedProjects="true">
+        <predicate
+            xsi:type="predicates:NotPredicate">
+          <operand
+              xsi:type="predicates:NamePredicate"
+              pattern="default_.*"/>
+        </predicate>
+      </sourceLocator>
+      <repositoryList>
+        <repository
+            url="https://download.itemis.com/updates/releases/2.1.0"/>
+        <repository
+            url="https://download.eclipse.org/cbi/updates/license"/>
+        <repository
+            url="https://download.eclipse.org/releases/${eclipse.target.platform}"/>
+        <repository
+            url="${xtext.latest.release.url}"/>
+        <repository
+            url="${mwe.latest.release.url}"/>
+      </repositoryList>
+    </targlet>
+  </setupTask>
+  <setupTask
+      xsi:type="setup.workingsets:WorkingSetTask"
+      id="xpect.workingsets"
+      prefix="org.eclipse.xpect-">
+    <workingSet
+        name="Xpect Plugins">
+      <predicate
+          xsi:type="predicates:AndPredicate">
+        <operand
+            xsi:type="predicates:RepositoryPredicate"
+            project="org.eclipse.xpect"/>
+        <operand
+            xsi:type="predicates:NaturePredicate"
+            nature="org.eclipse.pde.PluginNature"/>
+        <operand
+            xsi:type="workingsets:ExclusionPredicate"
+            excludedWorkingSet="//'xpect.workingsets'/@workingSets[name='Xpect%20Tests'] //'xpect.workingsets'/@workingSets[name='Xpect%20Examples']"/>
+      </predicate>
+    </workingSet>
+    <workingSet
+        name="Xpect Examples">
+      <predicate
+          xsi:type="predicates:AndPredicate">
+        <operand
+            xsi:type="predicates:NamePredicate"
+            pattern=".*example.*"/>
+        <operand
+            xsi:type="predicates:RepositoryPredicate"
+            project="org.eclipse.xpect"/>
+        <operand
+            xsi:type="predicates:NaturePredicate"
+            nature="org.eclipse.pde.PluginNature"/>
+        <operand
+            xsi:type="workingsets:ExclusionPredicate"
+            excludedWorkingSet="//'xpect.workingsets'/@workingSets[name='Xpect%20Tests']"/>
+      </predicate>
+    </workingSet>
+    <workingSet
+        name="Xpect Tests">
+      <predicate
+          xsi:type="predicates:AndPredicate">
+        <operand
+            xsi:type="predicates:NamePredicate"
+            pattern=".*tests"/>
+        <operand
+            xsi:type="predicates:RepositoryPredicate"
+            project="org.eclipse.xpect"/>
+        <operand
+            xsi:type="predicates:NaturePredicate"
+            nature="org.eclipse.pde.PluginNature"/>
+      </predicate>
+    </workingSet>
+    <workingSet
+        name="Xpect Features">
+      <predicate
+          xsi:type="predicates:AndPredicate">
+        <operand
+            xsi:type="predicates:RepositoryPredicate"
+            project="org.eclipse.xpect"/>
+        <operand
+            xsi:type="predicates:NaturePredicate"
+            nature="org.eclipse.pde.FeatureNature"/>
+      </predicate>
+    </workingSet>
+    <workingSet
+        name="Xpect Releng">
+      <predicate
+          xsi:type="predicates:AndPredicate">
+        <operand
+            xsi:type="predicates:RepositoryPredicate"
+            project="org.eclipse.xpect"/>
+        <operand
+            xsi:type="workingsets:ExclusionPredicate"
+            excludedWorkingSet="//'xpect.workingsets'/@workingSets[name='Xpect%20Features'] //'xpect.workingsets'/@workingSets[name='Xpect%20Plugins'] //'xpect.workingsets'/@workingSets[name='Xpect%20Tests'] //'xpect.workingsets'/@workingSets[name='Xpect%20Examples']"/>
+      </predicate>
+    </workingSet>
+    <description>The dynamic working sets for ${scope.project.label}</description>
+  </setupTask>
+  <stream name="master"
+      label="Master">
+    <setupTask
+        xsi:type="setup:EclipseIniTask"
+        option="-Doomph.redirection.xpect.git"
+        value="=https://raw.githubusercontent.com/eclipse/Xpect/master/org.eclipse.xpect.releng/Xpect.setup->${git.clone.xpect.location|uri}/org.eclipse.xpect.releng/Xpect.setup"
+        vm="true">
+      <description>
+        Set an Oomph redirection system property to redirect the logical location of this setup to its physical location in the Git clone.
+        Before enabling this task, replace '...' with the repository path of this setup's containing project.
+      </description>
+    </setupTask>
+  </stream>
+  <logicalProjectContainer
+      xsi:type="setup:ProjectCatalog"
+      href="index:/org.eclipse.setup#//@projectCatalogs[name='org.eclipse']"/>
+  <description>Xpect provides a development environment for working with Xpect's projects.</description>
+</setup:Project>

--- a/org.eclipse.xpect.releng/XpectConfiguration.setup
+++ b/org.eclipse.xpect.releng/XpectConfiguration.setup
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<setup:Configuration
+    xmi:version="2.0"
+    xmlns:xmi="http://www.omg.org/XMI"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:setup="http://www.eclipse.org/oomph/setup/1.0"
+    label="Xpect">
+  <annotation
+      source="http://www.eclipse.org/oomph/setup/BrandingInfo">
+    <detail
+        key="imageURI">
+      <value>https://www.eclipse.org/downloads/images/committers.png</value>
+    </detail>
+    <detail
+        key="badgeLabel">
+      <value>Xpect</value>
+    </detail>
+  </annotation>
+  <installation
+      name="xpect.installation"
+      label="Xpect Installation">
+    <productVersion
+        href="index:/org.eclipse.setup#//@productCatalogs[name='org.eclipse.products']/@products[name='epp.package.committers']/@versions[name='latest']"/>
+    <description>The Xpect installation provides the tools needed to work with  the set of projects from &lt;a href=&quot;https://github.com/eclipse/Xpect&quot;>Xpect's GitHub repository&lt;/a>.</description>
+  </installation>
+  <workspace
+      name="xpect.workspace"
+      label="Xpect Workspace">
+    <setupTask
+        xsi:type="setup:CompoundTask"
+        name="User Preferences">
+      <setupTask
+          xsi:type="setup:CompoundTask"
+          name="org.eclipse.ui.ide">
+        <setupTask
+            xsi:type="setup:PreferenceTask"
+            key="/instance/org.eclipse.ui.ide/WORKSPACE_NAME"
+            value="Xpect"/>
+      </setupTask>
+    </setupTask>
+    <stream
+        href="index:/org.eclipse.setup#//@projectCatalogs[name='org.eclipse']/@projects[name='xpect']/@streams[name='master']"/>
+    <description>The Xpect workspace provides the set of projects from &lt;a href=&quot;https://github.com/eclipse/Xpect&quot;>Xpects's GitHub repository&lt;/a>.</description>
+  </workspace>
+  <description>
+    &lt;p>
+    The Xpect configuration provisions a dedicated development environment for working with the set of projects from &lt;a href=&quot;https://github.com/eclipse/Xpect&quot;>Xpects's GitHub repository&lt;/a>.
+    &lt;/p>
+    &lt;p>
+    The installation is based on the latest EPP Committers package,
+    the workspace consists of the projects from Xpect's GitHub repository,
+    and the PDE target platform is based ongoing latest development.
+    &lt;p>
+    &lt;/p>
+    Please &lt;a href=&quot;https://wiki.eclipse.org/Eclipse_Platform_SDK_Provisioning&quot;>read the tutorial instructions&lt;/a> for more details about how to use a configuration.
+    &lt;/p>
+  </description>
+</setup:Configuration>

--- a/org.eclipse.xpect.releng/maven-plugin-parent/pom.xml
+++ b/org.eclipse.xpect.releng/maven-plugin-parent/pom.xml
@@ -17,7 +17,7 @@
 	<properties>
 		<target-platform>eclipse_2023_03-xtext_2_31_0</target-platform>
 		<xtextVersion>2.31.0</xtextVersion>
-		<tycho-version>2.7.5</tycho-version>
+		<tycho-version>4.0.3</tycho-version>
 		<target-platform-version>0.3.0-SNAPSHOT</target-platform-version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
@@ -279,7 +279,7 @@
 					<plugin>
 						<groupId>org.eclipse.cbi.maven.plugins</groupId>
 						<artifactId>eclipse-jarsigner-plugin</artifactId>
-						<version>1.3.2</version>
+						<version>1.4.2</version>
 						<executions>
 							<execution>
 								<id>sign</id>
@@ -376,9 +376,9 @@
 
 	<!-- Information about where the Xpect code lives. -->
 	<scm>
-		<connection>scm:git:git://github.com/eclipse/xpect.git</connection>
-		<developerConnection>scm:git:ssh://git@github.com:eclipse/xpect.git</developerConnection>
-		<url>https://github.com/eclipse/xpect</url>
+		<connection>scm:git:git://github.com/eclipse/Xpect.git</connection>
+		<developerConnection>scm:git:ssh://git@github.com:eclipse/Xpect.git</developerConnection>
+		<url>https://github.com/eclipse/Xpect</url>
 	</scm>
 
 

--- a/org.eclipse.xpect.releng/plugin.properties
+++ b/org.eclipse.xpect.releng/plugin.properties
@@ -1,3 +1,3 @@
 
 pluginName = org.eclipse.xpect.releng
-providerName = Eclipse Xpect Project
+providerName = Eclipse Xpect

--- a/org.eclipse.xpect.releng/promotion/pom.xml
+++ b/org.eclipse.xpect.releng/promotion/pom.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2023 Eclipse contributors and others.
+
+This program and the accompanying materials
+are made available under the terms of the Eclipse Public License 2.0
+which accompanies this distribution, and is available at
+https://www.eclipse.org/legal/epl-2.0/
+
+SPDX-License-Identifier: EPL-2.0
+-->
+<project
+	xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<artifactId>org.eclipse.xpect.repository.promotion</artifactId>
+	<packaging>pom</packaging>
+	<parent>
+		<groupId>org.eclipse.xpect</groupId>
+		<artifactId>org.eclipse.xpect.root</artifactId>
+		<version>0.3.0-SNAPSHOT</version>
+		<relativePath>../..</relativePath>
+	</parent>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho.extras</groupId>
+				<artifactId>tycho-eclipserun-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<configuration>
+					<executionEnvironment>JavaSE-17</executionEnvironment>
+					<dependencies>
+						<dependency>
+							<artifactId>org.eclipse.justj.p2</artifactId>
+							<type>eclipse-plugin</type>
+						</dependency>
+						<dependency>
+							<artifactId>org.apache.felix.scr</artifactId>
+							<type>eclipse-plugin</type>
+						</dependency>
+					</dependencies>
+					<repositories>
+						<repository>
+							<id>eclipse.repo</id>
+							<layout>p2</layout>
+							<url>${eclipse.repo}</url>
+						</repository>
+						<repository>
+							<id>justj.tools.repo</id>
+							<layout>p2</layout>
+							<url>${justj.tools.repo}</url>
+						</repository>
+					</repositories>
+				</configuration>
+				<executions>
+					<execution>
+						<id>promote</id>
+						<goals>
+							<goal>eclipse-run</goal>
+						</goals>
+						<phase>generate-sources</phase>
+						<configuration>
+							<argLine></argLine>
+							<applicationsArgs>
+								<applicationsArg>-consoleLog</applicationsArg>
+								<applicationsArg>-application</applicationsArg>
+								<applicationsArg>org.eclipse.justj.p2.manager</applicationsArg>
+								<applicationsArg>-data</applicationsArg>
+								<applicationsArg>@None</applicationsArg>
+								<applicationsArg>-nosplash</applicationsArg>
+								<applicationsArg>-remote</applicationsArg>
+								<applicationsArg>${org.eclipse.justj.p2.manager.remote}</applicationsArg>
+								<applicationsArg>-retain</applicationsArg>
+								<applicationsArg>5</applicationsArg>
+								<applicationsArg>-label</applicationsArg>
+								<applicationsArg>Xpect</applicationsArg>
+								<applicationsArg>-build-url</applicationsArg>
+								<applicationsArg>${org.eclipse.justj.p2.manager.build.url}</applicationsArg>
+								<applicationsArg>-root</applicationsArg>
+								<applicationsArg>${project.build.directory}/xpect-sync</applicationsArg>
+								<applicationsArg>-relative</applicationsArg>
+								<applicationsArg>${org.eclipse.justj.p2.manager.relative}</applicationsArg>
+								<applicationsArg>-excluded-categories-pattern</applicationsArg>
+								<applicationsArg>.*.Default</applicationsArg>
+								<applicationsArg>-iu-filter-pattern</applicationsArg>
+								<applicationsArg>org.eclipse.xpect.*</applicationsArg>
+								<applicationsArg>-version-iu</applicationsArg>
+								<applicationsArg>org.eclipse.xpect.sdk.</applicationsArg>
+								<applicationsArg>-commit</applicationsArg>
+								<applicationsArg>${git.url}/commit/${git.commit}</applicationsArg>
+								<applicationsArg>-target-url</applicationsArg>
+								<applicationsArg>https://download.eclipse.org/xpect</applicationsArg>
+								<applicationsArg>-promote</applicationsArg>
+								<applicationsArg>${project.basedir}/../p2-repository/target/repository</applicationsArg>
+								<applicationsArg>-timestamp</applicationsArg>
+								<applicationsArg>${build.timestamp}</applicationsArg>
+								<applicationsArg>-type</applicationsArg>
+								<applicationsArg>${build.type}</applicationsArg>
+								<applicationsArg>-breadcrumb</applicationsArg>
+								<applicationsArg>Xpect https://projects.eclipse.org/projects/modeling.xpect</applicationsArg>
+								<applicationsArg>-favicon</applicationsArg>
+								<applicationsArg>https://eclipseide.org/favicon.ico</applicationsArg>
+							</applicationsArgs>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/org.eclipse.xpect.releng/target-platforms/eclipse_2023_09-xtext_nightly/org.eclipse.xpect.target.eclipse_2023_09-xtext_nightly.target
+++ b/org.eclipse.xpect.releng/target-platforms/eclipse_2023_09-xtext_nightly/org.eclipse.xpect.target.eclipse_2023_09-xtext_nightly.target
@@ -27,6 +27,7 @@
 <unit id="org.hamcrest.core.source" version="2.2.0.v20230809-1000"/>
 <unit id="org.junit" version="4.13.2.v20230809-1000"/>
 <unit id="org.junit.source" version="4.13.2.v20230809-1000"/>
+<unit id="io.github.classgraph" version="0.0.0"/>
 <repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/2023-09"/>
 </location>
 </locations>

--- a/org.eclipse.xpect.releng/xtext-examples/org.eclipse.xtext.example.arithmetics/plugin.xml_gen
+++ b/org.eclipse.xpect.releng/xtext-examples/org.eclipse.xtext.example.arithmetics/plugin.xml_gen
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?eclipse version="3.0"?>
+<plugin>
+	<extension point="org.eclipse.emf.ecore.generated_package">
+		<package
+			uri = "http://www.eclipse.org/Xtext/example/Arithmetics"
+			class = "org.eclipse.xtext.example.arithmetics.arithmetics.ArithmeticsPackage"
+			genModel = "model/generated/Arithmetics.genmodel" />
+	</extension>
+</plugin>

--- a/org.eclipse.xpect.releng/xtext-examples/org.eclipse.xtext.example.domainmodel/plugin.xml_gen
+++ b/org.eclipse.xpect.releng/xtext-examples/org.eclipse.xtext.example.domainmodel/plugin.xml_gen
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?eclipse version="3.0"?>
+<plugin>
+	<extension point="org.eclipse.emf.ecore.generated_package">
+		<package
+			uri = "http://www.xtext.org/example/Domainmodel"
+			class = "org.eclipse.xtext.example.domainmodel.domainmodel.DomainmodelPackage"
+			genModel = "model/generated/Domainmodel.genmodel" />
+	</extension>
+</plugin>

--- a/org.eclipse.xpect.sdk/feature.properties
+++ b/org.eclipse.xpect.sdk/feature.properties
@@ -1,3 +1,3 @@
 
 featureName = org.eclipse.xpect.sdk
-providerName = Eclipse Xpect Project
+providerName = Eclipse Xpect

--- a/org.eclipse.xpect.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xpect.tests/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: org.eclipse.xpect.tests
-Bundle-Vendor: %providerName
+Bundle-Name: Xpect Tests
+Bundle-Vendor: Eclipse Xpect Project
 Bundle-Version: 0.3.0.qualifier
 Bundle-SymbolicName: org.eclipse.xpect.tests;singleton:=true
 Bundle-ActivationPolicy: lazy

--- a/org.eclipse.xpect.tests/plugin.properties
+++ b/org.eclipse.xpect.tests/plugin.properties
@@ -1,3 +1,3 @@
 
 pluginName = org.eclipse.xpect.tests
-providerName = Eclipse Xpect Project
+providerName = Eclipse Xpect

--- a/org.eclipse.xpect.ui.junit/META-INF/MANIFEST.MF
+++ b/org.eclipse.xpect.ui.junit/META-INF/MANIFEST.MF
@@ -1,8 +1,9 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Junit
-Bundle-SymbolicName: org.eclipse.xpect.ui.junit;singleton:=true
+Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
+Bundle-Localization: plugin
+Bundle-SymbolicName: org.eclipse.xpect.ui.junit;singleton:=true
 Bundle-Version: 0.3.0.qualifier
 Bundle-Activator: org.eclipse.xpect.ui.junit.Activator
 Require-Bundle: org.eclipse.xpect;bundle-version="[0.3.0,0.3.1)",

--- a/org.eclipse.xpect.ui.junit/plugin.properties
+++ b/org.eclipse.xpect.ui.junit/plugin.properties
@@ -1,3 +1,3 @@
 
-pluginName = org.eclipse.xpect.ui.junit
-providerName = Eclipse Xpect Project
+pluginName = Xpect JUnit
+providerName = Eclipse Xpect

--- a/org.eclipse.xpect.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.xpect.ui/META-INF/MANIFEST.MF
@@ -1,7 +1,8 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: org.eclipse.xpect.ui
+Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
+Bundle-Localization: plugin
 Bundle-Version: 0.3.0.qualifier
 Bundle-SymbolicName: org.eclipse.xpect.ui;singleton:=true
 Bundle-ActivationPolicy: lazy

--- a/org.eclipse.xpect.ui/plugin.properties
+++ b/org.eclipse.xpect.ui/plugin.properties
@@ -1,3 +1,3 @@
 
-pluginName = org.eclipse.xpect.ui
-providerName = Eclipse Xpect Project
+pluginName = Xpect UI
+providerName = Eclipse Xpect

--- a/org.eclipse.xpect.xtext.lib.feature/feature.properties
+++ b/org.eclipse.xpect.xtext.lib.feature/feature.properties
@@ -1,3 +1,3 @@
 
 featureName = org.eclipse.xpect.xtext.lib.feature
-providerName = Eclipse Xpect Project
+providerName = Eclipse Xpect

--- a/org.eclipse.xpect.xtext.lib.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xpect.xtext.lib.tests/META-INF/MANIFEST.MF
@@ -1,8 +1,9 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Tests
-Bundle-SymbolicName: org.eclipse.xpect.xtext.lib.tests;singleton:=true
+Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
+Bundle-Localization: plugin
+Bundle-SymbolicName: org.eclipse.xpect.xtext.lib.tests;singleton:=true
 Bundle-Version: 0.3.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.xpect.xtext.lib;bundle-version="0.3.0",

--- a/org.eclipse.xpect.xtext.lib.tests/build.properties
+++ b/org.eclipse.xpect.xtext.lib.tests/build.properties
@@ -2,4 +2,5 @@ source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\
                .,\
-               plugin.xml
+               plugin.xml,\
+               plugin.properties

--- a/org.eclipse.xpect.xtext.lib.tests/plugin.properties
+++ b/org.eclipse.xpect.xtext.lib.tests/plugin.properties
@@ -1,3 +1,3 @@
 
-pluginName = org.eclipse.xpect.xtext.lib.tests
-providerName = Eclipse Xpect Project
+pluginName = Xpect Xtext Lib Tests
+providerName = Eclipse Xpect

--- a/org.eclipse.xpect.xtext.lib/META-INF/MANIFEST.MF
+++ b/org.eclipse.xpect.xtext.lib/META-INF/MANIFEST.MF
@@ -1,8 +1,9 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Lib
-Bundle-SymbolicName: org.eclipse.xpect.xtext.lib
+Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
+Bundle-Localization: plugin
+Bundle-SymbolicName: org.eclipse.xpect.xtext.lib
 Bundle-Version: 0.3.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.7.0";visibility:=reexport,

--- a/org.eclipse.xpect.xtext.lib/plugin.properties
+++ b/org.eclipse.xpect.xtext.lib/plugin.properties
@@ -1,3 +1,3 @@
 
-pluginName = org.eclipse.xpect.xtext.lib
-providerName = Eclipse Xpect Project
+pluginName = Xpect Xtext Lib
+providerName = Eclipse Xpect

--- a/org.eclipse.xpect.xtext.xbase.lib.feature/feature.properties
+++ b/org.eclipse.xpect.xtext.xbase.lib.feature/feature.properties
@@ -1,3 +1,3 @@
 
 featureName = org.eclipse.xpect.xtext.xbase.lib.feature
-providerName = Eclipse Xpect Project
+providerName = Eclipse Xpect

--- a/org.eclipse.xpect.xtext.xbase.lib/META-INF/MANIFEST.MF
+++ b/org.eclipse.xpect.xtext.xbase.lib/META-INF/MANIFEST.MF
@@ -1,9 +1,10 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Lib
+Bundle-Name: %pluginName
+Bundle-Vendor: %providerName
+Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.xpect.xtext.xbase.lib
 Bundle-Version: 0.3.0.qualifier
-Bundle-Vendor: %providerName
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.7.0";visibility:=reexport,
  org.eclipse.core.resources;bundle-version="3.7.0";visibility:=reexport,

--- a/org.eclipse.xpect.xtext.xbase.lib/plugin.properties
+++ b/org.eclipse.xpect.xtext.xbase.lib/plugin.properties
@@ -1,3 +1,3 @@
 
-pluginName = org.eclipse.xpect.xtext.xbase.lib
-providerName = Eclipse Xpect Project
+pluginName = Xpect Xtext Xbase Lib
+providerName = Eclipse Xpect

--- a/org.eclipse.xpect/plugin.properties
+++ b/org.eclipse.xpect/plugin.properties
@@ -1,3 +1,3 @@
 
-pluginName = org.eclipse.xpect
-providerName = Eclipse Xpect Project
+pluginName =  Xpect
+providerName = Eclipse Xpect

--- a/org.eclipse.xtext.example.arithmetics.xpect.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.example.arithmetics.xpect.tests/META-INF/MANIFEST.MF
@@ -1,8 +1,9 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Tests
-Bundle-SymbolicName: org.eclipse.xtext.example.arithmetics.xpect.tests;singleton:=true
+Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
+Bundle-Localization: plugin
+Bundle-SymbolicName: org.eclipse.xtext.example.arithmetics.xpect.tests;singleton:=true
 Bundle-Version: 0.3.0.qualifier
 Fragment-Host: org.eclipse.xtext.example.arithmetics.ui 
 Bundle-RequiredExecutionEnvironment: JavaSE-11

--- a/org.eclipse.xtext.example.arithmetics.xpect.tests/plugin.properties
+++ b/org.eclipse.xtext.example.arithmetics.xpect.tests/plugin.properties
@@ -1,3 +1,3 @@
 
-pluginName = org.eclipse.xtext.example.arithmetics.xpect.tests
-providerName = Eclipse Xpect Project
+pluginName = Xtext Example Arithmetics Xpect Tests
+providerName = Eclipse Xpect

--- a/org.eclipse.xtext.example.arithmetics.xpect.tests/pom.xml
+++ b/org.eclipse.xtext.example.arithmetics.xpect.tests/pom.xml
@@ -20,7 +20,7 @@ Contributors:
 	<properties>
 		<os-jvm-flags />
 		<memory-settings>-Xmx1G</memory-settings>
-		<tycho-version>2.7.5</tycho-version>
+		<tycho-version>4.0.3</tycho-version>
 		<target-platform>eclipse_2023_03-xtext_2_31_0</target-platform>
 		<target-platform-version>0.3.0-SNAPSHOT</target-platform-version>
 	</properties>

--- a/org.eclipse.xtext.example.domainmodel.xpect.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.example.domainmodel.xpect.tests/META-INF/MANIFEST.MF
@@ -1,8 +1,9 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Tests
-Bundle-SymbolicName: org.eclipse.xtext.example.domainmodel.xpect.tests
+Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
+Bundle-Localization: plugin
+Bundle-SymbolicName: org.eclipse.xtext.example.domainmodel.xpect.tests
 Bundle-Version: 0.3.0.qualifier
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.xtext.example.domainmodel;bundle-version="2.31.0",

--- a/org.eclipse.xtext.example.domainmodel.xpect.tests/plugin.properties
+++ b/org.eclipse.xtext.example.domainmodel.xpect.tests/plugin.properties
@@ -1,3 +1,3 @@
 
-pluginName = org.eclipse.xtext.example.domainmodel.xpect.tests
-providerName = Eclipse Xpect Project
+pluginName = Xtext Example Domain Model Xpect Tests
+providerName = Eclipse Xpect

--- a/org.eclipse.xtext.example.domainmodel.xpect.tests/pom.xml
+++ b/org.eclipse.xtext.example.domainmodel.xpect.tests/pom.xml
@@ -19,7 +19,7 @@ Contributors:
 
 	<properties>
 		<memory-settings>-Xmx1G</memory-settings>
-		<tycho-version>2.7.5</tycho-version>
+		<tycho-version>4.0.3</tycho-version>
 		<target-platform>eclipse_2023_03-xtext_2_31_0</target-platform>
 		<target-platform-version>0.3.0-SNAPSHOT</target-platform-version>
 	</properties>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,18 @@
 		<maven.compiler.source>11</maven.compiler.source>
 		<maven.compiler.target>11</maven.compiler.target>
 		<target-platform>eclipse_2023_03-xtext_2_31_0</target-platform>
-		<tycho-version>2.7.5</tycho-version>
+		<tycho-version>4.0.3</tycho-version>
+
+		<!-- Used for promotion --> 
+		<eclipse.repo>https://download.eclipse.org/releases/2023-09</eclipse.repo>
+		<justj.tools.repo>https://download.eclipse.org/justj/tools/updates/nightly/latest</justj.tools.repo>
+		<git.url>https://github.com/eclipse/Xpect</git.url>
+		<org.eclipse.storage.user>genie.xpect</org.eclipse.storage.user>
+		<org.eclipse.justj.p2.manager.remote>${org.eclipse.storage.user}@projects-storage.eclipse.org:/home/data/httpd/download.eclipse.org/xpect</org.eclipse.justj.p2.manager.remote>
+		<org.eclipse.justj.p2.manager.extra.args></org.eclipse.justj.p2.manager.extra.args>
+		<org.eclipse.justj.p2.manager.relative>updates</org.eclipse.justj.p2.manager.relative>
+		<org.eclipse.justj.p2.manager.build.url>http://www.example.com/</org.eclipse.justj.p2.manager.build.url>
+		<build.type>nightly</build.type>
 	</properties> 
 
 	<build>
@@ -77,6 +88,15 @@
 				<module>org.eclipse.xpect.releng/maven-test-parent</module>
 				<module>org.eclipse.xpect.tests</module>
 				<module>org.eclipse.xpect.xtext.lib.tests</module>
+			</modules>
+		</profile>
+		<profile>
+			<id>promote</id>
+			<activation>
+				<activeByDefault>true</activeByDefault>
+			</activation>
+			<modules>
+				<module>org.eclipse.xpect.releng/promotion</module>
 			</modules>
 		</profile>
 	</profiles>


### PR DESCRIPTION
Improve the bundle names as they appear in the update sites. Upgrade to latest Tycho release.
Upgrade to the latest jarsigner.
Provide a functional Oomph setup, including a setup configuration and use it in
the CONTRIBUTING.md.
Ensure that the nightly target works.
Reduce workspace warnings.

https://github.com/eclipse/Xpect/issues/328
https://github.com/eclipse/Xpect/issues/330