### PR TITLE
Extract parts of XpectRunner singleton

### DIFF
--- a/org.eclipse.xpect.ui/src/org/eclipse/xpect/ui/util/XpectFileAccess.java
+++ b/org.eclipse.xpect.ui/src/org/eclipse/xpect/ui/util/XpectFileAccess.java
@@ -30,6 +30,7 @@ import org.eclipse.xpect.XpectConstants;
 import org.eclipse.xpect.XpectFile;
 import org.eclipse.xpect.registry.ILanguageInfo;
 import org.eclipse.xpect.runner.XpectRunner;
+import org.eclipse.xpect.runner.XpectTestGlobalState;
 
 import com.google.inject.Injector;
 
@@ -67,8 +68,8 @@ public class XpectFileAccess {
 		// need delegation or nothing because of "java" protocol
 		// result.setResourceFactoryRegistry(rs.getResourceFactoryRegistry());
 		result.setURIConverter(rs.getURIConverter());
-		if (XpectRunner.testClassloader != null) {
-			result.setClasspathURIContext(XpectRunner.testClassloader);
+		if (XpectTestGlobalState.INSTANCE.testClass() != null) {
+			result.setClasspathURIContext(XpectTestGlobalState.INSTANCE.testClass().getClassLoader());
 			result.setClasspathUriResolver(new ClassloaderClasspathUriResolver());
 		} else if (rs instanceof XtextResourceSet) {
 			XtextResourceSet xrs = (XtextResourceSet) rs;

--- a/org.eclipse.xpect.ui/src/org/eclipse/xpect/ui/util/XpectUtil.java
+++ b/org.eclipse.xpect.ui/src/org/eclipse/xpect/ui/util/XpectUtil.java
@@ -28,6 +28,7 @@ import org.eclipse.xtext.ui.util.JdtClasspathUriResolver;
 import org.eclipse.xpect.XpectFile;
 import org.eclipse.xpect.XpectJavaModel;
 import org.eclipse.xpect.runner.XpectRunner;
+import org.eclipse.xpect.runner.XpectTestGlobalState;
 import org.eclipse.xpect.ui.internal.XpectActivator;
 
 import com.google.inject.Injector;
@@ -40,8 +41,8 @@ public class XpectUtil {
 		Injector injector = XpectActivator.getInstance().getInjector(XpectActivator.ORG_ECLIPSE_XPECT_XPECT);
 		XtextResourceSet rs = new XtextResourceSet();
 		IJavaProject javaProject = JavaCore.create(file.getProject());
-		if (XpectRunner.testClassloader != null) {
-			rs.setClasspathURIContext(XpectRunner.testClassloader);
+		if (XpectTestGlobalState.INSTANCE.testClass() != null) {
+			rs.setClasspathURIContext(XpectTestGlobalState.INSTANCE.testClass().getClassLoader());
 			rs.setClasspathUriResolver(new ClassloaderClasspathUriResolver());
 		} else if (javaProject != null && javaProject.exists()) {
 			rs.setClasspathURIContext(javaProject);

--- a/org.eclipse.xpect/src/org/eclipse/xpect/runner/XpectRunner.java
+++ b/org.eclipse.xpect/src/org/eclipse/xpect/runner/XpectRunner.java
@@ -72,6 +72,12 @@ public class XpectRunner extends ParentRunner<Runner> {
 		this.uriProvider = findUriProvider(testClass);
 		this.xpectInjector = findXpectInjector();
 		this.xpectJavaModel = XpectJavaModelManager.createJavaModel(testClass);
+		/*
+		 * NOTE:
+		 * Do this before the state creation, otherwise the parts that depend on
+		 * the singleton won't initialize properly and tests will fail to run!
+		 */
+		XpectTestGlobalState.INSTANCE.set(xpectJavaModel, testClass);
 		this.state = TestExecutor.createState(createRootConfiguration());
 	}
 

--- a/org.eclipse.xpect/src/org/eclipse/xpect/runner/XpectTestGlobalState.java
+++ b/org.eclipse.xpect/src/org/eclipse/xpect/runner/XpectTestGlobalState.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Simeon Andreev and others.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Simeon Andreev - Initial contribution and API
+ *******************************************************************************/
+package org.eclipse.xpect.runner;
+
+import org.eclipse.xpect.XpectJavaModel;
+
+/**
+ * @author Simeon Andreev - Initial contribution and API
+ */
+public class XpectTestGlobalState {
+
+	public static final XpectTestGlobalState INSTANCE = new XpectTestGlobalState();
+
+	private XpectJavaModel model;
+	private Class<?> testClass;
+
+	public void set(XpectJavaModel model, Class<?> testClass) {
+		this.model = model;
+		this.testClass = testClass;
+	}
+
+	public XpectJavaModel model() {
+		return model;
+	}
+
+	public Class<?> testClass() {
+		return testClass;
+	}
+}

--- a/org.eclipse.xpect/src/org/eclipse/xpect/services/XtResourceServiceProviderProvider.java
+++ b/org.eclipse.xpect/src/org/eclipse/xpect/services/XtResourceServiceProviderProvider.java
@@ -17,6 +17,7 @@ import org.eclipse.xtext.resource.IResourceServiceProvider;
 import org.eclipse.xpect.XpectConstants;
 import org.eclipse.xpect.registry.ILanguageInfo;
 import org.eclipse.xpect.runner.XpectRunner;
+import org.eclipse.xpect.runner.XpectTestGlobalState;
 import org.eclipse.xpect.util.IXtInjectorProvider;
 
 import com.google.inject.Injector;
@@ -32,8 +33,8 @@ public class XtResourceServiceProviderProvider implements IResourceServiceProvid
 	}
 
 	public IResourceServiceProvider get(URI uri, String contentType) {
-		if (XpectRunner.INSTANCE != null) {
-			Injector injector = IXtInjectorProvider.INSTANCE.getInjector(XpectRunner.INSTANCE.getXpectJavaModel(), uri);
+		if (XpectTestGlobalState.INSTANCE.model() != null) {
+			Injector injector = IXtInjectorProvider.INSTANCE.getInjector(XpectTestGlobalState.INSTANCE.model(), uri);
 			if (injector != null)
 				return injector.getInstance(IResourceServiceProvider.class);
 		}

--- a/org.eclipse.xpect/src/org/eclipse/xpect/util/ClasspathUtil.java
+++ b/org.eclipse.xpect/src/org/eclipse/xpect/util/ClasspathUtil.java
@@ -26,6 +26,7 @@ import java.util.jar.Manifest;
 
 import org.apache.log4j.Logger;
 import org.eclipse.xpect.runner.XpectRunner;
+import org.eclipse.xpect.runner.XpectTestGlobalState;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.Sets;
@@ -81,8 +82,8 @@ public class ClasspathUtil {
 			}
 		}
 		// for some reason, ucl.getURLs() doesn't catch the current project in standalone maven surefire
-		if (XpectRunner.INSTANCE != null) {
-			Class<?> clazz = XpectRunner.INSTANCE.getTestClass().getJavaClass();
+		if (XpectTestGlobalState.INSTANCE.testClass() != null) {
+			Class<?> clazz = XpectTestGlobalState.INSTANCE.testClass();
 			String[] segments = clazz.getName().split("\\.");
 			String fileName = Joiner.on('/').join(segments) + ".class";
 			URL resource = clazz.getClassLoader().getResource(fileName);

--- a/org.eclipse.xpect/src/org/eclipse/xpect/util/EnvironmentUtil.java
+++ b/org.eclipse.xpect/src/org/eclipse/xpect/util/EnvironmentUtil.java
@@ -14,7 +14,7 @@ package org.eclipse.xpect.util;
 
 import org.eclipse.emf.ecore.plugin.EcorePlugin;
 import org.eclipse.xpect.Environment;
-import org.eclipse.xpect.runner.XpectRunner;
+import org.eclipse.xpect.runner.XpectTestGlobalState;
 
 import com.google.common.base.Joiner;
 
@@ -22,7 +22,7 @@ public class EnvironmentUtil {
 	public static final Environment ENVIRONMENT = detectEnvironement();
 
 	private static Environment detectEnvironement() {
-		if (XpectRunner.testClassloader != null) {
+		if (XpectTestGlobalState.INSTANCE.testClass() != null) {
 			if (EcorePlugin.IS_ECLIPSE_RUNNING)
 				return Environment.PLUGIN_TEST;
 			else


### PR DESCRIPTION
This change extracts parts of the singleton XpectRunner to another class, so that other implementations can set the values of the singleton.

This change is required, in order to provide alternatives of XpectRunner, such as a JUnit 5 alternative, without depending on XpectRunner.

Preparation for: #262