### PR TITLE
Fix NPE when Java Type is unresolvable.

### DIFF
--- a/org.eclipse.xpect/src/org/eclipse/xpect/scoping/XpectScopeProvider.java
+++ b/org.eclipse.xpect/src/org/eclipse/xpect/scoping/XpectScopeProvider.java
@@ -62,6 +62,9 @@ public class XpectScopeProvider extends AbstractScopeProvider {
 	private Set<JvmDeclaredType> getAssignableTypes(EObject context) {
 		EObject current = context;
 		XpectJavaModel xjm = EcoreUtil2.getContainerOfType(context, XpectFile.class).getJavaModel();
+		if (xjm == null) {
+			return Collections.emptySet();
+		}
 		ComponentUtil util = new ComponentUtil(xjm);
 		while (current != null) {
 			if (current instanceof Assignment)


### PR DESCRIPTION
An NPE is thrown when the java type isn't resolvable, so the missing NPE check was added to avoid this.