### PR TITLE
Upgrade Xpect to work with and build with the latest

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,7 @@ pipeline {
   environment {
     PUBLISH_LOCATION = 'updates'
     BUILD_TIMESTAMP = sh(returnStdout: true, script: 'date +%Y%m%d%H%M').trim()
-    TYCHO_VERSION = '4.0.10'
+    TYCHO_VERSION = '5.0.3'
     TARGET_PLATFORM_PRIMARY = 'xpect_r202403'
     TARGET_PLATFORM_LATEST = 'xpect_latest'
   }
@@ -78,7 +78,7 @@ BRANCH_NAME=${env.BRANCH_NAME}
     stage('Test With Latest') {
       steps {
         wrap([$class: 'Xvnc', useXauthority: true]) {
-          withMaven(jdk: 'temurin-jdk21-latest', maven: 'apache-maven-3.9.9', options: [junitPublisher(disabled: false)]) {
+          withMaven(jdk: 'temurin-jdk21-latest', maven: 'apache-maven-3.9.12', options: [junitPublisher(disabled: false)]) {
             dir('.') {
               sh '''
                 mvn \
@@ -104,7 +104,7 @@ BRANCH_NAME=${env.BRANCH_NAME}
       steps {
         sshagent(['projects-storage.eclipse.org-bot-ssh']) {
           wrap([$class: 'Xvnc', useXauthority: true]) {
-            withMaven(jdk: 'temurin-jdk17-latest', maven: 'apache-maven-3.9.9', options: [junitPublisher(disabled: false)]) {
+            withMaven(jdk: 'temurin-jdk21-latest', maven: 'apache-maven-3.9.12', options: [junitPublisher(disabled: false)]) {
               dir('.') {
                 sh '''
                   if [[ $PROMOTE != true ]]; then

--- a/org.eclipse.xpect.releng/Xpect - clean.launch
+++ b/org.eclipse.xpect.releng/Xpect - clean.launch
@@ -19,6 +19,6 @@
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_SHOW_CODEDETAILS_IN_EXCEPTION_MESSAGES" value="true"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_CLASSPATH_ONLY_JAR" value="false"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
-    <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17/"/>
+    <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21/"/>
     <stringAttribute key="org.eclipse.jdt.launching.WORKING_DIRECTORY" value="${workspace_loc:/org.eclipse.xpect.releng}/../"/>
 </launchConfiguration>

--- a/org.eclipse.xpect.releng/Xpect - install and test.launch
+++ b/org.eclipse.xpect.releng/Xpect - install and test.launch
@@ -21,6 +21,6 @@
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_SHOW_CODEDETAILS_IN_EXCEPTION_MESSAGES" value="true"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_CLASSPATH_ONLY_JAR" value="false"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
-    <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17/"/>
+    <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21/"/>
     <stringAttribute key="org.eclipse.jdt.launching.WORKING_DIRECTORY" value="${workspace_loc:/org.eclipse.xpect.releng}/../"/>
 </launchConfiguration>

--- a/org.eclipse.xpect.releng/Xpect - promote.launch
+++ b/org.eclipse.xpect.releng/Xpect - promote.launch
@@ -22,6 +22,6 @@
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_SHOW_CODEDETAILS_IN_EXCEPTION_MESSAGES" value="true"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_CLASSPATH_ONLY_JAR" value="false"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
-    <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17/"/>
+    <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21/"/>
     <stringAttribute key="org.eclipse.jdt.launching.WORKING_DIRECTORY" value="${workspace_loc:/org.eclipse.xpect.releng}/../"/>
 </launchConfiguration>

--- a/org.eclipse.xpect.releng/Xpect.setup
+++ b/org.eclipse.xpect.releng/Xpect.setup
@@ -164,9 +164,8 @@
   </setupTask>
   <setupTask
       xsi:type="jdt:JRETask"
-      version="JavaSE-17"
-      location="${jre.location-17}"
-      name="JRE for JavaSE-17">
+      version="JavaSE-21"
+      location="${jre.location-21}">
     <description>Define the JRE needed to compile and run the Java projects of ${scope.project.label}</description>
   </setupTask>
   <setupTask
@@ -184,13 +183,13 @@
   <setupTask
       xsi:type="setup:VariableTask"
       name="xtext.latest.release.url"
-      value="https://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.32.0">
+      value="https://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.43.0">
     <description>The p2 update site URL for the last Xtext release.</description>
   </setupTask>
   <setupTask
       xsi:type="setup:VariableTask"
       name="mwe.latest.release.url"
-      value="https://download.eclipse.org/modeling/emft/mwe/updates/releases/2.15.0">
+      value="https://download.eclipse.org/modeling/emft/mwe/updates/releases/2.26.0">
     <description>The p2 update site URL for the last MWE release.</description>
   </setupTask>
   <setupTask

--- a/org.eclipse.xpect.releng/maven-plugin-parent/pom.xml
+++ b/org.eclipse.xpect.releng/maven-plugin-parent/pom.xml
@@ -16,8 +16,8 @@
 
 	<properties>
 		<target-platform>xpect_r202403</target-platform>
-		<xtextVersion>2.31.0</xtextVersion>
-		<tycho-version>4.0.10</tycho-version>
+		<xtextVersion>2.43.0</xtextVersion>
+		<tycho-version>5.0.3</tycho-version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 
@@ -83,12 +83,6 @@
 							<goal>plugin-source</goal>
 						</goals>
 					</execution>
-					<execution>
-						<id>feature-source</id>
-						<goals>
-							<goal>feature-source</goal>
-						</goals>
-					</execution>
 				</executions>
 			</plugin>
 			<plugin>
@@ -115,6 +109,7 @@
 							${maven.multiModuleProjectDirectory}/${target-platform}.target
 						</file>
 					</target>
+					<executionEnvironment>JavaSE-21</executionEnvironment>
 					<environments>
 						<environment>
 							<os>macosx</os>

--- a/org.eclipse.xpect.releng/maven-test-parent/pom.xml
+++ b/org.eclipse.xpect.releng/maven-test-parent/pom.xml
@@ -49,10 +49,10 @@ Contributors:
 					<artifactId>tycho-surefire-plugin</artifactId>
 					<version>${tycho-version}</version>
 					<configuration>
-						<systemPropertyVariables>
+						<systemProperties>
 							<xpectTestTitlePostfix>.${target-platform}</xpectTestTitlePostfix>
 							<xpectTestTitleShowEnvironment>true</xpectTestTitleShowEnvironment>
-						</systemPropertyVariables>
+						</systemProperties>
 						<reportsDirectory>${project.build.directory}/surefire-reports-plugin</reportsDirectory>
 						<useUIHarness>true</useUIHarness>
 						<useUIThread>true</useUIThread>
@@ -64,15 +64,6 @@ Contributors:
 								<artifactId>org.eclipse.xtext.logging</artifactId>
 							</dependency>
 						</dependencies>
-						<dependency-resolution>
-							<extraRequirements>
-								<requirement>
-									<type>eclipse-feature</type>
-									<id>org.eclipse.rcp</id>
-									<versionRange>0.0.0</versionRange>
-								</requirement>
-							</extraRequirements>
-						</dependency-resolution>
 					</configuration>
 				</plugin>
 

--- a/org.eclipse.xpect.releng/org.eclipse.xpect.releng.utils/.settings/org.eclipse.jdt.core.prefs
+++ b/org.eclipse.xpect.releng/org.eclipse.xpect.releng.utils/.settings/org.eclipse.jdt.core.prefs
@@ -9,7 +9,6 @@ org.eclipse.jdt.core.compiler.debug.sourceFile=generate
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
 org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
 org.eclipse.jdt.core.compiler.release=enabled
 org.eclipse.jdt.core.compiler.source=17

--- a/org.eclipse.xpect.releng/p2-repository/category.xml
+++ b/org.eclipse.xpect.releng/p2-repository/category.xml
@@ -19,9 +19,7 @@ Contributors:
 	<bundle id="io.github.classgraph.source" version="0.0.0"/>
 	-->
 	<bundle id="org.hamcrest.core" version="0.0.0"/>
-	<bundle id="org.hamcrest.core.source" version="0.0.0"/>
 	<bundle id="org.junit" version="0.0.0"/>
-	<bundle id="org.junit.source" version="0.0.0"/>
 	<category-def name="Xpect 0.3.0" label="Xpect 0.3.0">
 		<description>
 			Tests for Xtext Languages

--- a/org.eclipse.xpect.releng/p2-repository/pom.xml
+++ b/org.eclipse.xpect.releng/p2-repository/pom.xml
@@ -24,8 +24,9 @@
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>tycho-p2-repository-plugin</artifactId>
 				<version>${tycho-version}</version>
-				<!-- <configuration> <includeAllDependencies>true</includeAllDependencies> 
-					</configuration> -->
+				<configuration>
+					<includeAllSources>true</includeAllSources>
+				</configuration>
 				<executions>
 					<execution>
 						<phase>package</phase>

--- a/org.eclipse.xpect.releng/promotion/pom.xml
+++ b/org.eclipse.xpect.releng/promotion/pom.xml
@@ -30,7 +30,7 @@ SPDX-License-Identifier: EPL-2.0
 				<artifactId>tycho-eclipserun-plugin</artifactId>
 				<version>${tycho-version}</version>
 				<configuration>
-					<executionEnvironment>JavaSE-17</executionEnvironment>
+					<executionEnvironment>JavaSE-21</executionEnvironment>
 					<dependencies>
 						<dependency>
 							<artifactId>org.eclipse.justj.p2</artifactId>

--- a/org.eclipse.xpect.releng/xtext-examples/org.eclipse.xtext.example.domainmodel/pom.xml
+++ b/org.eclipse.xpect.releng/xtext-examples/org.eclipse.xtext.example.domainmodel/pom.xml
@@ -22,9 +22,6 @@ Contributors:
 		<version>0.3.0-SNAPSHOT</version>
 		<relativePath>../maven-parents/grammar-plugin</relativePath>
 	</parent>
-	<properties>
-		<mwe2Version>2.14.0</mwe2Version>
-	</properties>
 
 	<build>
 		<plugins>

--- a/org.eclipse.xtext.example.arithmetics.xpect.tests/pom.xml
+++ b/org.eclipse.xtext.example.arithmetics.xpect.tests/pom.xml
@@ -20,7 +20,7 @@ Contributors:
 	<properties>
 		<os-jvm-flags />
 		<memory-settings>-Xmx1G</memory-settings>
-		<tycho-version>4.0.10</tycho-version>
+		<tycho-version>5.0.3</tycho-version>
 		<target-platform>xpect_r202403</target-platform>
 	</properties>
 
@@ -64,6 +64,7 @@ Contributors:
 							${maven.multiModuleProjectDirectory}/${target-platform}.target
 						</file>
 					</target>
+					<executionEnvironment>JavaSE-21</executionEnvironment>
 					<environments>
 						<environment>
 							<os>linux</os>

--- a/org.eclipse.xtext.example.domainmodel.xpect.tests/pom.xml
+++ b/org.eclipse.xtext.example.domainmodel.xpect.tests/pom.xml
@@ -19,7 +19,7 @@ Contributors:
 
 	<properties>
 		<memory-settings>-Xmx1G</memory-settings>
-		<tycho-version>4.0.10</tycho-version>
+		<tycho-version>5.0.3</tycho-version>
 		<target-platform>xpect_r202403</target-platform>
 	</properties>
 
@@ -47,6 +47,7 @@ Contributors:
 										${maven.multiModuleProjectDirectory}/${target-platform}.target
 									</file>
 								</target>
+								<executionEnvironment>JavaSE-21</executionEnvironment>
 								<environments>
 									<environment>
 										<os>linux</os>
@@ -66,10 +67,10 @@ Contributors:
 							<artifactId>tycho-surefire-plugin</artifactId>
 							<version>${tycho-version}</version>
 							<configuration>
-								<systemPropertyVariables>
+								<systemProperties>
 									<xpectTestTitlePostfix>.${target-platform}</xpectTestTitlePostfix>
 									<xpectTestTitleShowEnvironment>true</xpectTestTitleShowEnvironment>
-								</systemPropertyVariables>
+								</systemProperties>
 								<reportsDirectory>${project.build.directory}/surefire-reports-plugin</reportsDirectory>
 								<useUIHarness>true</useUIHarness>
 								<useUIThread>false</useUIThread>
@@ -109,6 +110,7 @@ Contributors:
 										${maven.multiModuleProjectDirectory}/${target-platform}.target
 									</file>
 								</target>
+								<executionEnvironment>JavaSE-21</executionEnvironment>
 								<environments>
 									<environment>
 										<os>macosx</os>
@@ -132,10 +134,10 @@ Contributors:
 								<useUIHarness>true</useUIHarness>
 								<useUIThread>false</useUIThread>
 								<argLine>${memory-settings} -XstartOnFirstThread</argLine>
-								<systemPropertyVariables>
+								<systemProperties>
 									<xpectTestTitlePostfix>.${target-platform}</xpectTestTitlePostfix>
 									<xpectTestTitleShowEnvironment>true</xpectTestTitleShowEnvironment>
-								</systemPropertyVariables>
+								</systemProperties>
 								<dependencies>
 									<dependency>
 										<type>eclipse-plugin</type>

--- a/pom.xml
+++ b/pom.xml
@@ -19,10 +19,10 @@
 		<maven.compiler.source>17</maven.compiler.source>
 		<maven.compiler.target>17</maven.compiler.target>
 		<target-platform>xpect_r202403</target-platform>
-		<tycho-version>4.0.10</tycho-version>
+		<tycho-version>5.0.3</tycho-version>
 
 		<!-- Used for promotion --> 
-		<eclipse.repo>https://download.eclipse.org/releases/2024-06</eclipse.repo>
+		<eclipse.repo>https://download.eclipse.org/releases/latest</eclipse.repo>
 		<justj.tools.repo>https://download.eclipse.org/justj/tools/updates/nightly/latest</justj.tools.repo>
 		<git.url>https://github.com/eclipse-xpect/Xpect</git.url>
 		<org.eclipse.storage.user>genie.xpect</org.eclipse.storage.user>

--- a/xpect_latest.target
+++ b/xpect_latest.target
@@ -23,13 +23,12 @@
 			<unit id="org.eclipse.jdt.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.platform.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.pde.feature.group" version="0.0.0"/>
-			<repository location="https://download.eclipse.org/eclipse/updates/4.40-I-builds"/>
+			<repository location="https://download.eclipse.org/eclipse/updates/4.41-I-builds"/>
 		</location>
 		
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="org.hamcrest.core" version="2.2.0.v20230809-1000"/>
-			<unit id="org.hamcrest.core.source" version="2.2.0.v20230809-1000"/>
-			<repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/2026-03"/>
+			<unit id="org.hamcrest.core" version="[2.2.0,3.0.0]"/>
+			<repository location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/2026-09"/>
 		</location>
 	</locations>
 </target>


### PR DESCRIPTION
- Upgrade to Tycho 5.0.3.
- Build with Java 21, while still targeting Java 17.
- Use Maven 3.9.12 rather than 3.9.9.
- Use Xtext 2.43.0.
- Eliminate feature-source and use includeAllSources to ensure that bundle sources are in the p2 repository, eliminating specify source bundle references from the category.xml.
- Specify executionEnvironment JavaSE-21 for target platform resolution.
- Eliminate build warnings to remove unused things and to upgrade to non-deprecated things.
- Remove org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning to avoid new (4.40) PDE error.
- Use Java 21 for promotion and use https://download.eclipse.org/releases/latest as the update site from which to materializes the promotion requirements.
- Upgrade m2e launchers to use Java 21.
- Remove unused mwe2Version property.
- Upgrade xpect_latest.target to 4.41/2026-09 repositories.
- Update the setup to proision a Java 21 JRE and use the latest Xtext/MWE releases.